### PR TITLE
Configure WhiteNoise for static files

### DIFF
--- a/fractalschool/settings.py
+++ b/fractalschool/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -115,6 +116,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field


### PR DESCRIPTION
## Summary
- set STATIC_ROOT for collected static files
- enable WhiteNoise middleware for serving static files

## Testing
- `python manage.py check`
- `python manage.py test`
- `pip show whitenoise`


------
https://chatgpt.com/codex/tasks/task_e_68a841fe8770832d83dee33b107703b1