### PR TITLE
Configure database via dj_database_url

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/fractalschool

--- a/fractalschool/settings.py
+++ b/fractalschool/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import dj_database_url
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -73,10 +74,7 @@ WSGI_APPLICATION = 'fractalschool.wsgi.application'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-    }
+    'default': dj_database_url.config(default='sqlite:///db.sqlite3')
 }
 
 


### PR DESCRIPTION
## Summary
- use dj_database_url to parse DATABASE_URL
- add .env with PostgreSQL connection string

## Testing
- `env $(cat .env | xargs) python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68a842028b70832d9396ac675172703a