### PR TITLE
Add deployment config files for gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN python manage.py collectstatic --noinput
+
+CMD ["gunicorn", "fractalschool.wsgi", "--bind", "0.0.0.0:8000"]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn fractalschool.wsgi

--- a/gunicorn.service
+++ b/gunicorn.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Gunicorn daemon for fractalschool project
+After=network.target
+
+[Service]
+User=www-data
+Group=www-data
+WorkingDirectory=/path/to/app
+Environment="PATH=/path/to/venv/bin"
+ExecStart=/path/to/venv/bin/gunicorn fractalschool.wsgi:application --bind 0.0.0.0:8000
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add Procfile for Heroku/Render deployment using gunicorn
- add Dockerfile to install deps, collect static files and run gunicorn
- add systemd service file template for running gunicorn persistently

## Testing
- `python3 manage.py check`
- `python3 manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a842135890832dbf6370e530e4d933