### PR TITLE
Add home page template and render view

### DIFF
--- a/fractalschool/settings.py
+++ b/fractalschool/settings.py
@@ -61,7 +61,7 @@ ROOT_URLCONF = 'fractalschool.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/fractalschool/views.py
+++ b/fractalschool/views.py
@@ -1,7 +1,7 @@
-from django.http import HttpResponse
+from django.shortcuts import render
 
 
 def home(request):
-    """Render a simple greeting on the home page."""
-    return HttpResponse("привет мир!")
+    """Render the main landing page."""
+    return render(request, "home.html")
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Fractal School</title>
+</head>
+<body>
+    <section>
+        <h2>Кто мы и что даём</h2>
+        <p>Мы рассказываем о фракталах и предлагаем обучение для всех желающих.</p>
+    </section>
+    <a href="{% url 'admin:login' %}">Вход в личный кабинет</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `home.html` with an introduction block and login link
- render the new template from the `home` view
- configure Django to search project-level `templates`

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a9642c99bc832d970903ca3fb0b1d4