### PR TITLE
Add Bootstrap base template with navigation

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Fractal School{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6j9FtiykGy" crossorigin="anonymous">
+</head>
+<body>
+<header>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="{% url 'home' %}">Fractal School</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="{% url 'admin:login' %}">Личный кабинет</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+</header>
+<main class="container mt-4">
+    {% block content %}{% endblock %}
+</main>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,14 +1,11 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="UTF-8">
-    <title>Fractal School</title>
-</head>
-<body>
-    <section>
-        <h2>Кто мы и что даём</h2>
-        <p>Мы рассказываем о фракталах и предлагаем обучение для всех желающих.</p>
-    </section>
-    <a href="{% url 'admin:login' %}">Вход в личный кабинет</a>
-</body>
-</html>
+{% extends 'base.html' %}
+
+{% block title %}Fractal School{% endblock %}
+
+{% block content %}
+<section>
+    <h2>Кто мы и что даём</h2>
+    <p>Мы рассказываем о фракталах и предлагаем обучение для всех желающих.</p>
+</section>
+<a href="{% url 'admin:login' %}" class="btn btn-primary">Вход в личный кабинет</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Bootstrap-based base template with responsive navbar and content container
- refactor home template to extend base and use Bootstrap styles

## Testing
- `python manage.py test`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68a96e570730832dbeb1c4ea4f4cea81