### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,25 @@
+.theme-dark {
+    background-color: #121212;
+    color: #f8f9fa;
+}
+
+.theme-dark a {
+    color: #9ecbff;
+}
+
+.theme-light {
+    background-color: #ffffff;
+    color: #212529;
+}
+
+.theme-light a {
+    color: #0d6efd;
+}
+
+#theme-toggle .fallback {
+    display: none;
+}
+
+#theme-toggle .icon:empty + .fallback {
+    display: inline;
+}

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const body = document.body;
+    const toggle = document.getElementById('theme-toggle');
+    if (!toggle) return;
+    const icon = toggle.querySelector('.icon');
+    const fallback = toggle.querySelector('.fallback');
+
+    let theme = localStorage.getItem('theme') || 'dark';
+    applyTheme(theme);
+
+    toggle.addEventListener('click', () => {
+        theme = theme === 'dark' ? 'light' : 'dark';
+        localStorage.setItem('theme', theme);
+        applyTheme(theme);
+    });
+
+    function applyTheme(current) {
+        const isDark = current === 'dark';
+        body.classList.toggle('theme-dark', isDark);
+        body.classList.toggle('theme-light', !isDark);
+        if (isDark) {
+            icon.textContent = '🌞';
+            fallback.textContent = 'дневная';
+        } else {
+            icon.textContent = '🌙';
+            fallback.textContent = 'ночная';
+        }
+    }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Fractal School{% endblock %}</title>
     <link rel="stylesheet" href="{% static 'bootstrap/bootstrap.min.css' %}">
+    <link rel="stylesheet" href="{% static 'css/theme.css' %}">
 </head>
 <body>
 <header>
@@ -20,6 +21,11 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{% url 'admin:login' %}">Личный кабинет</a>
                     </li>
+                    <li class="nav-item">
+                        <button id="theme-toggle" class="nav-link btn btn-link" type="button">
+                            <span class="icon">🌞</span><span class="fallback">дневная</span>
+                        </button>
+                    </li>
                 </ul>
             </div>
         </div>
@@ -29,5 +35,6 @@
     {% block content %}{% endblock %}
 </main>
     <script src="{% static 'bootstrap/bootstrap.bundle.min.js' %}"></script>
+    <script src="{% static 'js/theme.js' %}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add theme CSS for dark and light modes
- add toggle button with icon and fallback text
- include script to switch themes and persist user choice

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68aad5710074832daba88885df10d9e0