### PR TITLE
Remove personal account link from navigation

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,9 +18,11 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
+                    <!--
                     <li class="nav-item">
                         <a class="nav-link" href="{% url 'admin:login' %}">Личный кабинет</a>
                     </li>
+                    -->
                     <li class="nav-item">
                         <button id="theme-toggle" class="nav-link btn btn-link" type="button">
                             <span class="icon">🌞</span><span class="fallback">дневная</span>


### PR DESCRIPTION
## Summary
- comment out the Personal Account link in base template

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68aad7500eac832db2a9ec183948d8ff