### PR TITLE
Add hero section to homepage

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -33,6 +33,7 @@
         </div>
     </nav>
 </header>
+{% block hero %}{% endblock %}
 <main class="container mt-4">
     {% block content %}{% endblock %}
 </main>

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,6 +2,14 @@
 
 {% block title %}Fractal School{% endblock %}
 
+{% block hero %}
+<section class="py-5 text-center bg-light border-bottom">
+    <div class="container">
+        <p class="lead mb-0">Наша образовательная система использует только что вошедшие в нашу жизнь технологии, позволяющие индивидуально подбирать задания под каждого ученика</p>
+    </div>
+</section>
+{% endblock %}
+
 {% block content %}
 <section>
     <h2>Кто мы и что даём</h2>


### PR DESCRIPTION
## Summary
- allow pages to render optional hero blocks under the header
- display hero message on the home page about personalized learning

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68aadc8a6ca4832db89c99be24d5695e