### PR TITLE
Add hero section to homepage

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -23,3 +23,19 @@
 #theme-toggle .icon:empty + .fallback {
     display: inline;
 }
+
+.hero {
+    border-bottom: 1px solid;
+}
+
+.theme-light .hero {
+    background-color: #f8f9fa;
+    color: #212529;
+    border-color: #dee2e6;
+}
+
+.theme-dark .hero {
+    background-color: #212529;
+    color: #f8f9fa;
+    border-color: #343a40;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,6 +33,7 @@
         </div>
     </nav>
 </header>
+{% block hero %}{% endblock %}
 <main class="container mt-4">
     {% block content %}{% endblock %}
 </main>

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,6 +2,14 @@
 
 {% block title %}Fractal School{% endblock %}
 
+{% block hero %}
+<section class="hero py-5 text-center">
+    <div class="container">
+        <p class="lead mb-0">Наша образовательная система использует только что вошедшие в нашу жизнь технологии, позволяющие индивидуально подбирать задания под каждого ученика</p>
+    </div>
+</section>
+{% endblock %}
+
 {% block content %}
 <section>
     <h2>Кто мы и что даём</h2>


### PR DESCRIPTION
## Summary
- allow pages to render optional hero blocks under the header
- display hero message on the home page about personalized learning
- style hero block for dark theme visibility

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68aadc8a6ca4832db89c99be24d5695e