### PR TITLE
Require SECRET_KEY env var and document env settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SECRET_KEY=changeme
+# DEBUG accepts "True" to enable debug mode; defaults to False
+DEBUG=False
+# ALLOWED_HOSTS is optional, comma-separated list
+# ALLOWED_HOSTS=example.com,localhost

--- a/fractalschool/settings.py
+++ b/fractalschool/settings.py
@@ -22,13 +22,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get(
-    "SECRET_KEY",
-    "django-insecure-nma3r^3q4w^2fv)w(!%p5581!q&#ig&q(zi&s9u053yjtif3#7",
-)
+SECRET_KEY = os.environ["SECRET_KEY"]
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DEBUG", "True") == "True"
+DEBUG = os.environ.get("DEBUG", "False") == "True"
 
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "")
 ALLOWED_HOSTS = ALLOWED_HOSTS.split(",") if ALLOWED_HOSTS else []


### PR DESCRIPTION
## Summary
- Remove default SECRET_KEY and pull value from environment
- Configure DEBUG to read from DEBUG env var with False default
- Provide `.env.example` with SECRET_KEY, DEBUG, and ALLOWED_HOSTS entries

## Testing
- `SECRET_KEY=dev-secret python manage.py check`
- `SECRET_KEY=dev-secret python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68aafb440b28832d82b98b76697bc216