### PR TITLE
Use fallback secret key placeholder in settings

### DIFF
--- a/fractalschool/settings.py
+++ b/fractalschool/settings.py
@@ -22,7 +22,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ["SECRET_KEY"]
+SECRET_KEY = os.environ.get("SECRET_KEY", "django-insecure-placeholder")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", "False") == "True"


### PR DESCRIPTION
## Summary
- load SECRET_KEY from env variable with default insecure placeholder

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ac03a93478832db682c96df90c218c