### PR TITLE
feat: add collapsible hero information block

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -28,9 +28,11 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 
 /* Hero */
 .hero { padding: 56px 0 28px; border-bottom: 1px solid var(--border); background: radial-gradient(1200px 600px at 70% -100px, color-mix(in srgb, var(--accent) 20%, transparent), transparent); }
-.hero h1 { font-size: clamp(28px, 5vw, 44px); margin: 0 0 12px; line-height: 1.1; }
+.hero .title { font-size: clamp(28px, 5vw, 44px); margin: 0; line-height: 1.1; }
 .hero p { margin: 0 0 20px; color: var(--muted); max-width: 720px; }
-.hero .cta { display: flex; gap: 12px; flex-wrap: wrap; }
+.hero details summary { padding: 0; }
+.hero details summary .chev { color: var(--accent); }
+.hero details p { margin-top: 12px; }
 .btn-secondary { background: transparent; border: 1px solid var(--border); color: var(--text); }
 
 /* Accordion */

--- a/templates/home.html
+++ b/templates/home.html
@@ -5,12 +5,14 @@
 {% block content %}
   <section class="hero">
     <div class="container">
-      <h1>Нейросети + технологии 2025 → персональный курс для каждого</h1>
-      <p>Мы используем нейросетевые алгоритмы, чтобы программа обучения подстраивалась под ваш темп, уровень и цели. Гибко, прозрачно, результативно.</p>
-      <div class="cta">
-        <a href="#signup" class="btn">Начать обучение</a>
-        <a href="#grades" class="btn btn-secondary">Выбрать класс</a>
-      </div>
+      <h1 class="sr">Технологии 2025 на службе образования</h1>
+      <details class="tech-2025">
+        <summary>
+          <span class="title">Технологии 2025 на службе образования</span>
+          <svg class="chev" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </summary>
+        <p>То, что вчера казалось фантастикой, сегодня становится реальностью. Мы используем современные алгоритмы рекомендаций, чтобы подбирать каждому ученику именно те задания, которые дадут наилучший результат. Все задания при этом генерируются в строгом соответствии с требованиями ФИПИ.</p>
+      </details>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- replace hero section text with collapsible technology block
- style new block and link to match site theme
- indicate hero block expands with arrow icon

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68ac242b05c0832da8e2b0fd6d78eca1