### PR TITLE
Add personal dashboard and custom signup

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,14 +1,40 @@
+from django import forms
 from django.contrib.auth import get_user_model
-from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
+from django.contrib.auth.forms import AuthenticationForm
 
 User = get_user_model()
 
 
-class SignupForm(UserCreationForm):
-    class Meta:
-        model = User
-        fields = ("username", "email", "password1", "password2")
+class SignupForm(forms.Form):
+    contact = forms.CharField(label="Контактные данные", max_length=255)
+    username = forms.CharField(label="Логин", max_length=150)
+    password = forms.CharField(label="Пароль", widget=forms.PasswordInput)
+
+    def clean_username(self):
+        username = self.cleaned_data["username"]
+        if User.objects.filter(username=username).exists():
+            raise forms.ValidationError("Этот логин уже занят")
+        return username
+
+    def save(self, commit: bool = True):
+        user = User(username=self.cleaned_data["username"], email=self.cleaned_data["contact"])
+        user.set_password(self.cleaned_data["password"])
+        if commit:
+            user.save()
+        return user
 
 
 class LoginForm(AuthenticationForm):
     pass
+
+
+class UsernameChangeForm(forms.ModelForm):
+    class Meta:
+        model = User
+        fields = ("username",)
+
+    def clean_username(self):
+        username = self.cleaned_data["username"]
+        if User.objects.filter(username=username).exclude(pk=self.instance.pk).exists():
+            raise forms.ValidationError("Этот логин уже занят")
+        return username

--- a/accounts/templates/accounts/dashboard.html
+++ b/accounts/templates/accounts/dashboard.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{% block title %}Личный кабинет{% endblock %}
+
+{% block content %}
+<h1>Личный кабинет</h1>
+<form method="post">
+    {% csrf_token %}
+    {{ u_form.as_p }}
+    <button type="submit" name="username_submit" class="btn">Изменить логин</button>
+</form>
+<form method="post">
+    {% csrf_token %}
+    {{ p_form.as_p }}
+    <button type="submit" name="password_submit" class="btn">Изменить пароль</button>
+</form>
+{% endblock %}

--- a/accounts/templates/accounts/signup.html
+++ b/accounts/templates/accounts/signup.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
 
-{% block title %}Sign Up{% endblock %}
+{% block title %}Регистрация{% endblock %}
 
 {% block content %}
-<h1>Sign Up</h1>
+<h1>Регистрация</h1>
 <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit" class="btn btn-primary">Register</button>
+    <button type="submit" class="btn">Зарегистрироваться</button>
 </form>
-<p><a href="{% url 'accounts:login' %}">Login</a></p>
+<p><a href="{% url 'accounts:login' %}">Войти</a></p>
 {% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -8,6 +8,7 @@ app_name = "accounts"
 
 urlpatterns = [
     path("signup/", views.signup, name="signup"),
+    path("dashboard/", views.dashboard, name="dashboard"),
     path(
         "login/",
         auth_views.LoginView.as_view(

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,7 +1,9 @@
-from django.contrib.auth import login
+from django.contrib.auth import login, update_session_auth_hash
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.forms import PasswordChangeForm
 from django.shortcuts import redirect, render
 
-from .forms import SignupForm
+from .forms import SignupForm, UsernameChangeForm
 
 
 def signup(request):
@@ -15,3 +17,29 @@ def signup(request):
     else:
         form = SignupForm()
     return render(request, "accounts/signup.html", {"form": form})
+
+
+@login_required
+def dashboard(request):
+    if request.method == "POST":
+        if "username_submit" in request.POST:
+            u_form = UsernameChangeForm(request.POST, instance=request.user)
+            p_form = PasswordChangeForm(request.user)
+            if u_form.is_valid():
+                u_form.save()
+                return redirect("accounts:dashboard")
+        elif "password_submit" in request.POST:
+            u_form = UsernameChangeForm(instance=request.user)
+            p_form = PasswordChangeForm(request.user, request.POST)
+            if p_form.is_valid():
+                user = p_form.save()
+                update_session_auth_hash(request, user)
+                return redirect("accounts:dashboard")
+    else:
+        u_form = UsernameChangeForm(instance=request.user)
+        p_form = PasswordChangeForm(request.user)
+    return render(
+        request,
+        "accounts/dashboard.html",
+        {"u_form": u_form, "p_form": p_form},
+    )

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,6 +16,7 @@
           <span>Фрактал: школа будущего</span>
         </a>
         <a href="#signup" class="btn">Записаться</a>
+        <a href="{% if user.is_authenticated %}{% url 'accounts:dashboard' %}{% else %}{% url 'accounts:signup' %}{% endif %}" class="btn">Логин/Личный кабинет</a>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- Add custom signup form with contact info, username and password
- Create user dashboard allowing login and password changes
- Expose Login/Personal Cabinet button in site header

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b28de27148832d9b974f909a3a0bfa