### PR TITLE
Configure CSRF trusted origins via environment

### DIFF
--- a/fractalschool/settings.py
+++ b/fractalschool/settings.py
@@ -30,6 +30,13 @@ DEBUG = os.environ.get("DEBUG", "False") == "True"
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "")
 ALLOWED_HOSTS = ALLOWED_HOSTS.split(",") if ALLOWED_HOSTS else []
 
+CSRF_TRUSTED_ORIGINS = os.environ.get(
+    "CSRF_TRUSTED_ORIGINS", "https://web-production-d6aee.up.railway.app"
+)
+CSRF_TRUSTED_ORIGINS = (
+    CSRF_TRUSTED_ORIGINS.split(",") if CSRF_TRUSTED_ORIGINS else []
+)
+
 
 # Application definition
 


### PR DESCRIPTION
## Summary
- add `CSRF_TRUSTED_ORIGINS` setting configurable via env var

## Testing
- `python manage.py check`
- `python manage.py test`
- `ALLOWED_HOSTS=localhost DEBUG=True python manage.py runserver` (started and halted)


------
https://chatgpt.com/codex/tasks/task_e_68b2a7755f00832d9c4fb606f8b0d5ff