### PR TITLE
feat: expose skill group list under exam version API

### DIFF
--- a/apps/recsys/api/urls.py
+++ b/apps/recsys/api/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
     path("api/next-task/", NextTaskView.as_view(), name="next-task"),
     path("api/progress/", ProgressView.as_view(), name="progress"),
     path(
-        "api/skill-groups/<int:exam_version_id>/",
+        "api/exam-versions/<int:exam_version_id>/skill-groups/",
         SkillGroupListView.as_view(),
         name="skill-group-list",
     ),

--- a/apps/recsys/tests/test_skill_groups.py
+++ b/apps/recsys/tests/test_skill_groups.py
@@ -30,7 +30,9 @@ class SkillGroupAPITests(TestCase):
 
     def test_api_returns_groups(self):
         self.client.force_login(self.user)
-        resp = self.client.get(f"/api/skill-groups/{self.exam.id}/")
+        resp = self.client.get(
+            f"/api/exam-versions/{self.exam.id}/skill-groups/"
+        )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
         self.assertEqual(len(data), 2)


### PR DESCRIPTION
## Summary
- expose skill group list under exam version API path
- adjust tests for new skill group endpoint

## Testing
- `python manage.py test` *(fails: SkillMastery.DoesNotExist, expected status 200 got 403, recompute mastery mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b80ef028832db3f7ae6cfc57dfbf