### PR TITLE
Expose subject and exam version in admin and API

### DIFF
--- a/apps/recsys/admin.py
+++ b/apps/recsys/admin.py
@@ -29,11 +29,13 @@ class SubjectAdmin(admin.ModelAdmin):
 @admin.register(Skill)
 class SkillAdmin(admin.ModelAdmin):
     list_display = ("name", "subject")
+    list_filter = ("subject",)
 
 
 @admin.register(TaskType)
 class TaskTypeAdmin(admin.ModelAdmin):
     list_display = ("name", "subject")
+    list_filter = ("subject",)
 
 
 @admin.register(Task)
@@ -65,6 +67,7 @@ class SkillGroupInline(admin.TabularInline):
 class ExamVersionAdmin(admin.ModelAdmin):
     inlines = [SkillGroupInline]
     list_display = ("name", "subject")
+    list_filter = ("subject",)
 
 
 admin.site.register(TaskSkill)

--- a/apps/recsys/api/serializers.py
+++ b/apps/recsys/api/serializers.py
@@ -17,13 +17,13 @@ from ..models import (
 class SkillSerializer(serializers.ModelSerializer):
     class Meta:
         model = Skill
-        fields = ["id", "name", "description"]
+        fields = ["id", "subject", "name", "description"]
 
 
 class TaskTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = TaskType
-        fields = ["id", "name", "description"]
+        fields = ["id", "subject", "name", "description"]
 
 
 class TaskSkillSerializer(serializers.ModelSerializer):
@@ -35,10 +35,20 @@ class TaskSkillSerializer(serializers.ModelSerializer):
 class TaskSerializer(serializers.ModelSerializer):
     type = TaskTypeSerializer(read_only=True)
     skills = SkillSerializer(many=True, read_only=True)
+    subject = serializers.PrimaryKeyRelatedField(read_only=True)
+    exam_version = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Task
-        fields = ["id", "type", "title", "description", "skills"]
+        fields = [
+            "id",
+            "subject",
+            "exam_version",
+            "type",
+            "title",
+            "description",
+            "skills",
+        ]
 
 
 class AttemptSerializer(serializers.ModelSerializer):
@@ -89,10 +99,11 @@ class SkillGroupItemSerializer(serializers.ModelSerializer):
 
 class SkillGroupSerializer(serializers.ModelSerializer):
     items = SkillGroupItemSerializer(many=True, read_only=True)
+    exam_version = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = SkillGroup
-        fields = ["id", "title", "items"]
+        fields = ["id", "exam_version", "title", "items"]
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- include subject filters for skills, task types, and exam versions in Django admin
- expose subject and exam version fields on task, skill, task type, and skill group serializers

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b7d7ae401c832d91a1a4a75e2a8132