### PR TITLE
Add account dashboard base and progress view

### DIFF
--- a/accounts/templates/accounts/dashboard.html
+++ b/accounts/templates/accounts/dashboard.html
@@ -1,17 +1,14 @@
-{% extends 'base.html' %}
+{% extends 'accounts/dashboard/base.html' %}
 
-{% block title %}Личный кабинет{% endblock %}
+{% block dashboard_title %}Прогресс{% endblock %}
 
-{% block content %}
-<h1>Личный кабинет</h1>
-<form method="post">
-    {% csrf_token %}
-    {{ u_form.as_p }}
-    <button type="submit" name="username_submit" class="btn">Изменить логин</button>
-</form>
-<form method="post">
-    {% csrf_token %}
-    {{ p_form.as_p }}
-    <button type="submit" name="password_submit" class="btn">Изменить пароль</button>
-</form>
+{% block dashboard_content %}
+<h1>Прогресс пользователя</h1>
+<ul>
+  {% for mastery in skill_masteries %}
+    <li>{{ mastery.skill.name }}: {{ mastery.mastery|floatformat:2 }}</li>
+  {% empty %}
+    <li>Прогресс отсутствует.</li>
+  {% endfor %}
+</ul>
 {% endblock %}

--- a/accounts/templates/accounts/dashboard/base.html
+++ b/accounts/templates/accounts/dashboard/base.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+
+{% block title %}{% block dashboard_title %}{% endblock %}{% endblock %}
+
+{% block content %}
+<div class="dashboard-container" style="display:flex; gap:2rem;">
+  <aside class="dashboard-sidebar" style="width:200px;">
+    <nav>
+      <ul>
+        <li class="{% if active_tab == 'progress' %}active{% endif %}"><a href="{% url 'accounts:dashboard' %}">Прогресс</a></li>
+        <li class="{% if active_tab == 'teachers' %}active{% endif %}"><a href="#">Мои учителя</a></li>
+        <li class="{% if active_tab == 'classes' %}active{% endif %}"><a href="#">Мои классы</a></li>
+        <li class="{% if active_tab == 'settings' %}active{% endif %}"><a href="#">Настройки</a></li>
+      </ul>
+    </nav>
+  </aside>
+  <section class="dashboard-content" style="flex:1;">
+    {% block dashboard_content %}{% endblock %}
+  </section>
+</div>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -8,7 +8,7 @@ app_name = "accounts"
 
 urlpatterns = [
     path("signup/", views.signup, name="signup"),
-    path("dashboard/", views.dashboard, name="dashboard"),
+    path("dashboard/", views.progress, name="dashboard"),
     path(
         "login/",
         auth_views.LoginView.as_view(

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,9 +1,10 @@
-from django.contrib.auth import login, update_session_auth_hash
+from django.contrib.auth import login
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.forms import PasswordChangeForm
-from django.shortcuts import redirect, render
+from django.shortcuts import render, redirect
 
-from .forms import SignupForm, UsernameChangeForm
+from apps.recsys.models import SkillMastery
+
+from .forms import SignupForm
 
 
 def signup(request):
@@ -20,26 +21,12 @@ def signup(request):
 
 
 @login_required
-def dashboard(request):
-    if request.method == "POST":
-        if "username_submit" in request.POST:
-            u_form = UsernameChangeForm(request.POST, instance=request.user)
-            p_form = PasswordChangeForm(request.user)
-            if u_form.is_valid():
-                u_form.save()
-                return redirect("accounts:dashboard")
-        elif "password_submit" in request.POST:
-            u_form = UsernameChangeForm(instance=request.user)
-            p_form = PasswordChangeForm(request.user, request.POST)
-            if p_form.is_valid():
-                user = p_form.save()
-                update_session_auth_hash(request, user)
-                return redirect("accounts:dashboard")
-    else:
-        u_form = UsernameChangeForm(instance=request.user)
-        p_form = PasswordChangeForm(request.user)
-    return render(
-        request,
-        "accounts/dashboard.html",
-        {"u_form": u_form, "p_form": p_form},
+def progress(request):
+    """Display progress for the current user."""
+    masteries = (
+        SkillMastery.objects.filter(user=request.user)
+        .select_related("skill")
+        .order_by("skill__name")
     )
+    context = {"skill_masteries": masteries, "active_tab": "progress"}
+    return render(request, "accounts/dashboard.html", context)


### PR DESCRIPTION
## Summary
- Create reusable dashboard base template with sidebar navigation for accounts
- Replace dashboard page with progress view displaying SkillMastery data
- Route /accounts/dashboard/ to new progress view and provide active tab context

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b822c54e4c832dad52d04bd026eed5