### PR TITLE
Add teachers dashboard placeholder

### DIFF
--- a/accounts/templates/accounts/dashboard/base.html
+++ b/accounts/templates/accounts/dashboard/base.html
@@ -8,7 +8,7 @@
     <nav>
       <ul>
         <li class="{% if active_tab == 'progress' %}active{% endif %}"><a href="{% url 'accounts:dashboard' %}">Прогресс</a></li>
-        <li class="{% if active_tab == 'teachers' %}active{% endif %}"><a href="#">Мои учителя</a></li>
+        <li class="{% if active_tab == 'teachers' %}active{% endif %}"><a href="{% url 'accounts:dashboard-teachers' %}">Мои учителя</a></li>
         <li class="{% if active_tab == 'classes' %}active{% endif %}"><a href="#">Мои классы</a></li>
         <li class="{% if active_tab == 'settings' %}active{% endif %}"><a href="#">Настройки</a></li>
       </ul>

--- a/accounts/templates/accounts/dashboard/teachers.html
+++ b/accounts/templates/accounts/dashboard/teachers.html
@@ -1,0 +1,7 @@
+{% extends 'accounts/dashboard/base.html' %}
+
+{% block dashboard_title %}Мои учителя{% endblock %}
+
+{% block dashboard_content %}
+<p>Здесь будет список учителей.</p>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -9,6 +9,7 @@ app_name = "accounts"
 urlpatterns = [
     path("signup/", views.signup, name="signup"),
     path("dashboard/", views.progress, name="dashboard"),
+    path("dashboard/teachers/", views.dashboard_teachers, name="dashboard-teachers"),
     path(
         "login/",
         auth_views.LoginView.as_view(

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -30,3 +30,10 @@ def progress(request):
     )
     context = {"skill_masteries": masteries, "active_tab": "progress"}
     return render(request, "accounts/dashboard.html", context)
+
+
+@login_required
+def dashboard_teachers(request):
+    """Display a placeholder teachers dashboard."""
+    context = {"active_tab": "teachers"}
+    return render(request, "accounts/dashboard/teachers.html", context)


### PR DESCRIPTION
## Summary
- add teachers dashboard view and route
- scaffold template for teachers dashboard
- link teachers dashboard from sidebar

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b8276913fc832d8ac26cd00c0c3feb