### PR TITLE
Add stub classes dashboard view and template

### DIFF
--- a/accounts/templates/accounts/dashboard/base.html
+++ b/accounts/templates/accounts/dashboard/base.html
@@ -9,7 +9,7 @@
       <ul>
         <li class="{% if active_tab == 'progress' %}active{% endif %}"><a href="{% url 'accounts:dashboard' %}">Прогресс</a></li>
         <li class="{% if active_tab == 'teachers' %}active{% endif %}"><a href="{% url 'accounts:dashboard-teachers' %}">Мои учителя</a></li>
-        <li class="{% if active_tab == 'classes' %}active{% endif %}"><a href="#">Мои классы</a></li>
+        <li class="{% if active_tab == 'classes' %}active{% endif %}"><a href="{% url 'accounts:dashboard-classes' %}">Мои классы</a></li>
         <li class="{% if active_tab == 'settings' %}active{% endif %}"><a href="#">Настройки</a></li>
       </ul>
     </nav>

--- a/accounts/templates/accounts/dashboard/classes.html
+++ b/accounts/templates/accounts/dashboard/classes.html
@@ -1,0 +1,7 @@
+{% extends 'accounts/dashboard/base.html' %}
+
+{% block dashboard_title %}Мои классы{% endblock %}
+
+{% block dashboard_content %}
+<p>Здесь будут мои классы.</p>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path("signup/", views.signup, name="signup"),
     path("dashboard/", views.progress, name="dashboard"),
     path("dashboard/teachers/", views.dashboard_teachers, name="dashboard-teachers"),
+    path("dashboard/classes/", views.dashboard_classes, name="dashboard-classes"),
     path(
         "login/",
         auth_views.LoginView.as_view(

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -37,3 +37,10 @@ def dashboard_teachers(request):
     """Display a placeholder teachers dashboard."""
     context = {"active_tab": "teachers"}
     return render(request, "accounts/dashboard/teachers.html", context)
+
+
+@login_required
+def dashboard_classes(request):
+    """Display a placeholder classes dashboard."""
+    context = {"active_tab": "classes"}
+    return render(request, "accounts/dashboard/classes.html", context)


### PR DESCRIPTION
## Summary
- add placeholder classes dashboard view and template
- wire up URL and sidebar link for classes dashboard

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b8288492dc832d9c0ccf41cbd8bf91