### PR TITLE
Add dashboard settings page

### DIFF
--- a/accounts/templates/accounts/dashboard/base.html
+++ b/accounts/templates/accounts/dashboard/base.html
@@ -10,7 +10,7 @@
         <li class="{% if active_tab == 'progress' %}active{% endif %}"><a href="{% url 'accounts:dashboard' %}">Прогресс</a></li>
         <li class="{% if active_tab == 'teachers' %}active{% endif %}"><a href="{% url 'accounts:dashboard-teachers' %}">Мои учителя</a></li>
         <li class="{% if active_tab == 'classes' %}active{% endif %}"><a href="{% url 'accounts:dashboard-classes' %}">Мои классы</a></li>
-        <li class="{% if active_tab == 'settings' %}active{% endif %}"><a href="#">Настройки</a></li>
+        <li class="{% if active_tab == 'settings' %}active{% endif %}"><a href="{% url 'accounts:dashboard-settings' %}">Настройки</a></li>
       </ul>
     </nav>
   </aside>

--- a/accounts/templates/accounts/dashboard/settings.html
+++ b/accounts/templates/accounts/dashboard/settings.html
@@ -1,0 +1,17 @@
+{% extends 'accounts/dashboard/base.html' %}
+
+{% block dashboard_title %}Настройки{% endblock %}
+
+{% block dashboard_content %}
+<h1>Настройки</h1>
+<form method="post">
+    {% csrf_token %}
+    {{ u_form.as_p }}
+    <button type="submit" name="username_submit" class="btn">Изменить логин</button>
+</form>
+<form method="post">
+    {% csrf_token %}
+    {{ p_form.as_p }}
+    <button type="submit" name="password_submit" class="btn">Изменить пароль</button>
+</form>
+{% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path("dashboard/", views.progress, name="dashboard"),
     path("dashboard/teachers/", views.dashboard_teachers, name="dashboard-teachers"),
     path("dashboard/classes/", views.dashboard_classes, name="dashboard-classes"),
+    path("dashboard/settings/", views.dashboard_settings, name="dashboard-settings"),
     path(
         "login/",
         auth_views.LoginView.as_view(


### PR DESCRIPTION
## Summary
- implement dedicated dashboard settings view for username and password updates
- add settings template and sidebar link
- expose dashboard settings via URL

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b82a0a6ce0832d80bd40ce6b55c01b