### PR TITLE
Clean up dashboard layout styles

### DIFF
--- a/accounts/templates/accounts/dashboard/base.html
+++ b/accounts/templates/accounts/dashboard/base.html
@@ -3,8 +3,8 @@
 {% block title %}{% block dashboard_title %}{% endblock %}{% endblock %}
 
 {% block content %}
-<div class="dashboard-container" style="display:flex; gap:2rem;">
-  <aside class="dashboard-sidebar" style="width:200px;">
+<div class="dashboard-container container">
+  <aside class="dashboard-sidebar">
     <nav>
       <ul>
         <li class="{% if active_tab == 'progress' %}active{% endif %}"><a href="{% url 'accounts:dashboard' %}">Прогресс</a></li>
@@ -14,7 +14,7 @@
       </ul>
     </nav>
   </aside>
-  <section class="dashboard-content" style="flex:1;">
+  <section class="dashboard-content">
     {% block dashboard_content %}{% endblock %}
   </section>
 </div>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -66,6 +66,11 @@ details[open] .chev { transform: rotate(180deg); }
 .cta-block { text-align: center; padding: 28px 0 48px; }
 .muted { color: var(--muted); }
 
+/* Dashboard */
+.dashboard-container { display:flex; gap:2rem; }
+.dashboard-sidebar { width:200px; }
+.dashboard-content { flex:1; }
+
 /* Utility */
 .sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
 


### PR DESCRIPTION
## Summary
- Wrap dashboard template in the shared `container` class and strip inline layout styles
- Define CSS rules for dashboard layout elements in `main.css`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b8779eaa58832db795b3e76a4e455f