### PR TITLE
feat(accounts): allow updating user profile

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -38,3 +38,23 @@ class UsernameChangeForm(forms.ModelForm):
         if User.objects.filter(username=username).exclude(pk=self.instance.pk).exists():
             raise forms.ValidationError("Этот логин уже занят")
         return username
+
+
+class UserUpdateForm(forms.ModelForm):
+    """Form for updating basic user information."""
+
+    class Meta:
+        model = User
+        fields = ("username", "first_name", "last_name", "email")
+        labels = {
+            "username": "Логин",
+            "first_name": "Имя",
+            "last_name": "Фамилия",
+            "email": "Электронная почта",
+        }
+
+    def clean_username(self):
+        username = self.cleaned_data["username"]
+        if User.objects.filter(username=username).exclude(pk=self.instance.pk).exists():
+            raise forms.ValidationError("Этот логин уже занят")
+        return username

--- a/accounts/templates/accounts/dashboard/settings.html
+++ b/accounts/templates/accounts/dashboard/settings.html
@@ -7,7 +7,7 @@
 <form method="post">
     {% csrf_token %}
     {{ u_form.as_p }}
-    <button type="submit" name="username_submit" class="btn">Изменить логин</button>
+    <button type="submit" name="user_submit" class="btn">Сохранить изменения</button>
 </form>
 <form method="post">
     {% csrf_token %}

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,3 +1,51 @@
 from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
 
-# Create your tests here.
+User = get_user_model()
+
+
+class DashboardSettingsTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="user1", password="pass", email="user1@example.com"
+        )
+
+    def test_update_user_information(self):
+        self.client.login(username="user1", password="pass")
+        url = reverse("accounts:dashboard-settings")
+        response = self.client.post(
+            url,
+            {
+                "username": "newuser",
+                "first_name": "Иван",
+                "last_name": "Иванов",
+                "email": "new@example.com",
+                "user_submit": "",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, "newuser")
+        self.assertEqual(self.user.first_name, "Иван")
+        self.assertEqual(self.user.last_name, "Иванов")
+        self.assertEqual(self.user.email, "new@example.com")
+
+    def test_duplicate_username_error(self):
+        User.objects.create_user(
+            username="user2", password="pass2", email="user2@example.com"
+        )
+        self.client.login(username="user1", password="pass")
+        url = reverse("accounts:dashboard-settings")
+        response = self.client.post(
+            url,
+            {
+                "username": "user2",
+                "first_name": "Имя",
+                "last_name": "Фамилия",
+                "email": "user1@example.com",
+                "user_submit": "",
+            },
+        )
+        self.assertContains(response, "Этот логин уже занят")

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -5,7 +5,7 @@ from django.shortcuts import render, redirect
 
 from apps.recsys.models import SkillMastery
 
-from .forms import SignupForm, UsernameChangeForm
+from .forms import SignupForm, UserUpdateForm
 
 
 def signup(request):
@@ -50,24 +50,24 @@ def dashboard_classes(request):
 @login_required
 def dashboard_settings(request):
     if request.method == "POST":
-        if "username_submit" in request.POST:
-            u_form = UsernameChangeForm(request.POST, instance=request.user)
+        if "user_submit" in request.POST:
+            u_form = UserUpdateForm(request.POST, instance=request.user)
             p_form = PasswordChangeForm(request.user)
             if u_form.is_valid():
                 u_form.save()
                 return redirect("accounts:dashboard-settings")
         elif "password_submit" in request.POST:
-            u_form = UsernameChangeForm(instance=request.user)
+            u_form = UserUpdateForm(instance=request.user)
             p_form = PasswordChangeForm(request.user, request.POST)
             if p_form.is_valid():
                 user = p_form.save()
                 update_session_auth_hash(request, user)
                 return redirect("accounts:dashboard-settings")
         else:
-            u_form = UsernameChangeForm(instance=request.user)
+            u_form = UserUpdateForm(instance=request.user)
             p_form = PasswordChangeForm(request.user)
     else:
-        u_form = UsernameChangeForm(instance=request.user)
+        u_form = UserUpdateForm(instance=request.user)
         p_form = PasswordChangeForm(request.user)
     context = {"u_form": u_form, "p_form": p_form, "active_tab": "settings"}
     return render(request, "accounts/dashboard/settings.html", context)


### PR DESCRIPTION
## Summary
- let users update username, personal details and email
- keep password change in separate form
- cover user profile update and duplicate username cases with tests

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b898ebc3ac832d8f24efe518910274