### PR TITLE
feat: localize user settings forms and template

### DIFF
--- a/accounts/templates/accounts/dashboard/settings.html
+++ b/accounts/templates/accounts/dashboard/settings.html
@@ -1,17 +1,36 @@
 {% extends 'accounts/dashboard/base.html' %}
+{% load i18n %}
 
-{% block dashboard_title %}Настройки{% endblock %}
+{% block dashboard_title %}{% trans "Настройки" %}{% endblock %}
 
 {% block dashboard_content %}
-<h1>Настройки</h1>
+<h1>{% trans "Настройки" %}</h1>
 <form method="post">
     {% csrf_token %}
-    {{ u_form.as_p }}
-    <button type="submit" name="user_submit" class="btn">Сохранить изменения</button>
+    {{ u_form.non_field_errors }}
+    {% for field in u_form %}
+        <div class="mb-3">
+            <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+            {{ field }}
+            {% if field.errors %}
+                <div class="errorlist">{{ field.errors }}</div>
+            {% endif %}
+        </div>
+    {% endfor %}
+    <button type="submit" name="user_submit" class="btn">{% trans "Сохранить изменения" %}</button>
 </form>
 <form method="post">
     {% csrf_token %}
-    {{ p_form.as_p }}
-    <button type="submit" name="password_submit" class="btn">Изменить пароль</button>
+    {{ p_form.non_field_errors }}
+    {% for field in p_form %}
+        <div class="mb-3">
+            <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+            {{ field }}
+            {% if field.errors %}
+                <div class="errorlist">{{ field.errors }}</div>
+            {% endif %}
+        </div>
+    {% endfor %}
+    <button type="submit" name="password_submit" class="btn">{% trans "Изменить пароль" %}</button>
 </form>
 {% endblock %}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,11 +1,10 @@
 from django.contrib.auth import login, update_session_auth_hash
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.forms import PasswordChangeForm
 from django.shortcuts import render, redirect
 
 from apps.recsys.models import SkillMastery
 
-from .forms import SignupForm, UserUpdateForm
+from .forms import SignupForm, UserUpdateForm, PasswordChangeForm
 
 
 def signup(request):


### PR DESCRIPTION
## Summary
- provide Russian labels and error messages for the user profile form
- add Russian-labelled password change form and use it in views
- render forms manually in the settings template with i18n tags

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b89aba4eb4832d876157c599080434