### PR TITLE
Add dashboard role switcher and adaptive navigation

### DIFF
--- a/accounts/templates/accounts/dashboard/base.html
+++ b/accounts/templates/accounts/dashboard/base.html
@@ -8,7 +8,7 @@
     <nav>
       <ul>
         <li class="{% if active_tab == 'progress' %}active{% endif %}"><a href="{% url 'accounts:dashboard' %}">Прогресс</a></li>
-        <li class="{% if active_tab == 'teachers' %}active{% endif %}"><a href="{% url 'accounts:dashboard-teachers' %}">Мои учителя</a></li>
+        <li class="{% if active_tab == 'teachers' %}active{% endif %}"><a href="{% url 'accounts:dashboard-teachers' %}">{% if role == 'teacher' %}Мои ученики{% else %}Мои учителя{% endif %}</a></li>
         <li class="{% if active_tab == 'classes' %}active{% endif %}"><a href="{% url 'accounts:dashboard-classes' %}">Мои классы</a></li>
         <li class="{% if active_tab == 'settings' %}active{% endif %}"><a href="{% url 'accounts:dashboard-settings' %}">Настройки</a></li>
       </ul>

--- a/accounts/templates/accounts/dashboard/settings.html
+++ b/accounts/templates/accounts/dashboard/settings.html
@@ -5,6 +5,19 @@
 
 {% block dashboard_content %}
 <h1>{% trans "Настройки" %}</h1>
+{% if request.user.teacherprofile and request.user.studentprofile %}
+<form method="post">
+    {% csrf_token %}
+    <div class="mb-3">
+        <label for="id_role">{% trans "Режим кабинета" %}</label>
+        <select name="role" id="id_role">
+            <option value="student" {% if role == 'student' %}selected{% endif %}>{% trans "Ученик" %}</option>
+            <option value="teacher" {% if role == 'teacher' %}selected{% endif %}>{% trans "Учитель" %}</option>
+        </select>
+    </div>
+    <button type="submit" name="role_submit" class="btn">{% trans "Сменить режим" %}</button>
+</form>
+{% endif %}
 <form method="post">
     {% csrf_token %}
     {{ u_form.non_field_errors }}

--- a/accounts/templates/accounts/dashboard/teachers.html
+++ b/accounts/templates/accounts/dashboard/teachers.html
@@ -1,7 +1,11 @@
 {% extends 'accounts/dashboard/base.html' %}
 
-{% block dashboard_title %}Мои учителя{% endblock %}
+{% block dashboard_title %}{% if role == 'teacher' %}Мои ученики{% else %}Мои учителя{% endif %}{% endblock %}
 
 {% block dashboard_content %}
+{% if role == 'teacher' %}
+<p>Здесь будет список учеников.</p>
+{% else %}
 <p>Здесь будет список учителей.</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Allow users to switch between student and teacher modes in dashboard settings
- Display navigation and teacher page labels based on selected mode
- Persist chosen mode in session with helper function

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b58e4ffc832daa8535cfffa92028