### PR TITLE
Improve dashboard settings design with visible role toggle

### DIFF
--- a/accounts/templates/accounts/dashboard/settings.html
+++ b/accounts/templates/accounts/dashboard/settings.html
@@ -4,25 +4,26 @@
 {% block dashboard_title %}{% trans "Настройки" %}{% endblock %}
 
 {% block dashboard_content %}
-<h1>{% trans "Настройки" %}</h1>
+<h1 class="mb-16">{% trans "Настройки" %}</h1>
 {% if request.user.teacherprofile and request.user.studentprofile %}
-<form method="post">
+<form method="post" class="card mb-16">
     {% csrf_token %}
-    <div class="mb-3">
-        <label for="id_role">{% trans "Режим кабинета" %}</label>
-        <select name="role" id="id_role">
-            <option value="student" {% if role == 'student' %}selected{% endif %}>{% trans "Ученик" %}</option>
-            <option value="teacher" {% if role == 'teacher' %}selected{% endif %}>{% trans "Учитель" %}</option>
-        </select>
+    <h2 class="mb-8">{% trans "Режим кабинета" %}</h2>
+    <div class="role-toggle mb-16">
+        <input type="radio" id="role-student" name="role" value="student" {% if role == 'student' %}checked{% endif %}>
+        <label for="role-student">{% trans "Ученик" %}</label>
+        <input type="radio" id="role-teacher" name="role" value="teacher" {% if role == 'teacher' %}checked{% endif %}>
+        <label for="role-teacher">{% trans "Учитель" %}</label>
     </div>
     <button type="submit" name="role_submit" class="btn">{% trans "Сменить режим" %}</button>
 </form>
 {% endif %}
-<form method="post">
+<form method="post" class="card mb-16">
     {% csrf_token %}
+    <h2 class="mb-8">{% trans "Личная информация" %}</h2>
     {{ u_form.non_field_errors }}
     {% for field in u_form %}
-        <div class="mb-3">
+        <div class="mb-16">
             <label for="{{ field.id_for_label }}">{{ field.label }}</label>
             {{ field }}
             {% if field.errors %}
@@ -32,11 +33,12 @@
     {% endfor %}
     <button type="submit" name="user_submit" class="btn">{% trans "Сохранить изменения" %}</button>
 </form>
-<form method="post">
+<form method="post" class="card">
     {% csrf_token %}
+    <h2 class="mb-8">{% trans "Изменить пароль" %}</h2>
     {{ p_form.non_field_errors }}
     {% for field in p_form %}
-        <div class="mb-3">
+        <div class="mb-16">
             <label for="{{ field.id_for_label }}">{{ field.label }}</label>
             {{ field }}
             {% if field.errors %}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -75,6 +75,16 @@ details[open] .chev { transform: rotate(180deg); }
 .dashboard-sidebar li.active a { color:var(--accent); }
 .dashboard-content { flex:1; }
 
+/* Dashboard settings */
+.dashboard-content form { background: var(--card); border:1px solid var(--border); border-radius:12px; padding:20px; }
+.dashboard-content form h2 { margin-top:0; }
+.dashboard-content label { display:block; margin-bottom:4px; }
+.dashboard-content input, .dashboard-content select { width:100%; padding:8px; border:1px solid var(--border); border-radius:8px; background:var(--bg); color:var(--text); }
+.role-toggle { display:flex; gap:8px; }
+.role-toggle input { display:none; }
+.role-toggle label { flex:1; text-align:center; padding:10px 0; border:1px solid var(--border); border-radius:10px; background:var(--card); cursor:pointer; }
+.role-toggle input:checked + label { background:var(--accent); color:#001420; border-color:color-mix(in srgb, var(--accent) 70%, black); }
+
 /* Utility */
 .sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
 


### PR DESCRIPTION
## Summary
- restyle dashboard settings page using card layout and spacing utilities
- add prominent radio-button toggle for switching between student and teacher modes
- style dashboard forms and role toggle in main CSS

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b8b86e90832d8e00336790735931