### PR TITLE
Create student profile via user post-save signal

### DIFF
--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class AccountsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "accounts"
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/accounts/signals.py
+++ b/accounts/signals.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import StudentProfile
+
+
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_student_profile(sender, instance, created, **kwargs):
+    if created:
+        StudentProfile.objects.get_or_create(user=instance)


### PR DESCRIPTION
## Summary
- add post-save signal to automatically create `StudentProfile` when a user is created
- load signal module in app config

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b8bf3b3800832d8e663c6b89e27f96