### PR TITLE
Add placeholder on dashboard page

### DIFF
--- a/accounts/templates/accounts/dashboard.html
+++ b/accounts/templates/accounts/dashboard.html
@@ -1,14 +1,7 @@
 {% extends 'accounts/dashboard/base.html' %}
 
-{% block dashboard_title %}Прогресс{% endblock %}
+{% block dashboard_title %}Задания{% endblock %}
 
 {% block dashboard_content %}
-<h1>Прогресс пользователя</h1>
-<ul>
-  {% for mastery in skill_masteries %}
-    <li>{{ mastery.skill.name }}: {{ mastery.mastery|floatformat:2 }}</li>
-  {% empty %}
-    <li>Прогресс отсутствует.</li>
-  {% endfor %}
-</ul>
+<p>тут будут ваши задания</p>
 {% endblock %}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,7 +2,6 @@ from django.contrib.auth import login, update_session_auth_hash
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect
 
-from apps.recsys.models import SkillMastery
 
 from .forms import SignupForm, UserUpdateForm, PasswordChangeForm
 
@@ -39,15 +38,9 @@ def signup(request):
 
 @login_required
 def progress(request):
-    """Display progress for the current user."""
-    masteries = (
-        SkillMastery.objects.filter(user=request.user)
-        .select_related("skill")
-        .order_by("skill__name")
-    )
+    """Temporary placeholder for the dashboard page."""
     role = _get_dashboard_role(request)
     context = {
-        "skill_masteries": masteries,
         "active_tab": "tasks",
         "role": role,
     }


### PR DESCRIPTION
## Summary
- replace progress content with placeholder text
- simplify dashboard view to serve placeholder

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b958230e6c832db2a643db4106212f