### PR TITLE
Improve signup page styling and contact guidance

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -10,7 +10,13 @@ User = get_user_model()
 
 
 class SignupForm(forms.Form):
-    contact = forms.CharField(label=_("Контактные данные"), max_length=255)
+    contact = forms.CharField(
+        label=_("Контактные данные"),
+        max_length=255,
+        help_text=_(
+            "Укажите email или телефон — они понадобятся для восстановления аккаунта"
+        ),
+    )
     username = forms.CharField(label=_("Логин"), max_length=150)
     password = forms.CharField(label=_("Пароль"), widget=forms.PasswordInput)
 

--- a/accounts/templates/accounts/signup.html
+++ b/accounts/templates/accounts/signup.html
@@ -1,13 +1,47 @@
 {% extends 'base.html' %}
+{% load i18n %}
 
-{% block title %}Регистрация{% endblock %}
+{% block title %}{% trans "Регистрация" %}{% endblock %}
 
 {% block content %}
-<h1>Регистрация</h1>
-<form method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="btn">Зарегистрироваться</button>
-</form>
-<p><a href="{% url 'accounts:login' %}">Войти</a></p>
+<section class="section">
+  <div class="container">
+    <h1 class="mb-16">{% trans "Регистрация" %}</h1>
+    <form method="post" class="auth-form">
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+
+      <div class="mb-16">
+        <label for="{{ form.contact.id_for_label }}">{{ form.contact.label }}</label>
+        {{ form.contact }}
+        {% if form.contact.help_text %}
+          <small class="helptext">{{ form.contact.help_text }}</small>
+        {% endif %}
+        {% if form.contact.errors %}
+          <div class="errorlist">{{ form.contact.errors }}</div>
+        {% endif %}
+      </div>
+
+      <div class="mb-16">
+        <label for="{{ form.username.id_for_label }}">{{ form.username.label }}</label>
+        {{ form.username }}
+        {% if form.username.errors %}
+          <div class="errorlist">{{ form.username.errors }}</div>
+        {% endif %}
+      </div>
+
+      <div class="mb-16">
+        <label for="{{ form.password.id_for_label }}">{{ form.password.label }}</label>
+        {{ form.password }}
+        {% if form.password.errors %}
+          <div class="errorlist">{{ form.password.errors }}</div>
+        {% endif %}
+      </div>
+
+      <button type="submit" class="btn">{% trans "Зарегистрироваться" %}</button>
+    </form>
+    <p class="mt-16"><a href="{% url 'accounts:login' %}">{% trans "Войти" %}</a></p>
+  </div>
+</section>
 {% endblock %}
+

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -66,6 +66,12 @@ details[open] .chev { transform: rotate(180deg); }
 .cta-block { text-align: center; padding: 28px 0 48px; }
 .muted { color: var(--muted); }
 
+/* Auth forms */
+.auth-form { background: var(--card); border:1px solid var(--border); border-radius:12px; padding:20px; max-width:400px; }
+.auth-form label { display:block; margin-bottom:4px; }
+.auth-form input { width:100%; padding:8px; border:1px solid var(--border); border-radius:8px; background:var(--bg); color:var(--text); }
+.auth-form .helptext { display:block; margin-top:4px; color:var(--muted); font-size:14px; }
+
 /* Dashboard */
 .dashboard-container { display:flex; gap:2rem; }
 .dashboard-sidebar { width:200px; }


### PR DESCRIPTION
## Summary
- Style signup page to match site layout and card-based forms
- Add note explaining contacts are required for account recovery
- Introduce shared auth form CSS for consistent input styling

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ba8f934e38832d9bf02acc4d192b1f