### PR TITLE
Add logout route and dashboard link

### DIFF
--- a/accounts/templates/accounts/dashboard/settings.html
+++ b/accounts/templates/accounts/dashboard/settings.html
@@ -48,4 +48,5 @@
     {% endfor %}
     <button type="submit" name="password_submit" class="btn">{% trans "Изменить пароль" %}</button>
 </form>
+<a href="{% url 'accounts:logout' %}" class="btn mt-16">{% trans "Выйти из аккаунта" %}</a>
 {% endblock %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -21,4 +21,5 @@ urlpatterns = [
         ),
         name="login",
     ),
+    path("logout/", auth_views.LogoutView.as_view(), name="logout"),
 ]


### PR DESCRIPTION
## Summary
- expose auth LogoutView at `/accounts/logout/`
- add logout button on dashboard settings page

## Testing
- `python manage.py test`
- `python manage.py shell`

------
https://chatgpt.com/codex/tasks/task_e_68bac40dfc78832db3c4239fe20ff2c4