### PR TITLE
Replace logout link with POST form

### DIFF
--- a/accounts/templates/accounts/dashboard/settings.html
+++ b/accounts/templates/accounts/dashboard/settings.html
@@ -48,5 +48,8 @@
     {% endfor %}
     <button type="submit" name="password_submit" class="btn">{% trans "Изменить пароль" %}</button>
 </form>
-<a href="{% url 'accounts:logout' %}" class="btn mt-16">{% trans "Выйти из аккаунта" %}</a>
+<form method="post" action="{% url 'accounts:logout' %}">
+    {% csrf_token %}
+    <button type="submit" class="btn mt-16">{% trans "Выйти из аккаунта" %}</button>
+</form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- submit logout from dashboard settings via POST form

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bac66aacd4832d896c68da150cfc5e