### PR TITLE
Move signup button into hero section

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -17,7 +17,6 @@
         <h1>Фрактал: школа будущего<span class="cursor">_</span></h1>
       </a>
       <nav class="toolbar">
-        <a href="#signup" class="btn accent">Записаться</a>
         <a href="{% if user.is_authenticated %}{% url 'accounts:dashboard' %}{% else %}{% url 'accounts:signup' %}{% endif %}" class="btn">
             {% if user.is_authenticated %}
                 Мой кабинет: 👤 {{ request.user.username }}

--- a/templates/home.html
+++ b/templates/home.html
@@ -12,7 +12,7 @@
       </div>
       <p style="text-align:center; margin:0 0 16px;">Запишитесь на занятия прямо сейчас!</p>
       <div style="text-align:center; margin-bottom:24px;">
-        <a class="btn" href="#signup">Записаться</a>
+        <a class="btn accent" href="#signup">Записаться</a>
       </div>
       <details class="accordion">
         <summary>


### PR DESCRIPTION
## Summary
- remove duplicate signup button from toolbar in base template
- highlight signup link in home page hero with accent styling

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bacbd78c14832dbe11c12ac08d74dc