### PR TITLE
Display avatar initial and center it with flex

### DIFF
--- a/static/css/cyber.css
+++ b/static/css/cyber.css
@@ -23,8 +23,10 @@ header{
 }
 .brand{display:flex; align-items:center; gap:16px; padding:12px 24px;}
 .avatar{
+  display:flex; align-items:center; justify-content:center;
   width:42px; height:42px; border-radius:10px; background:linear-gradient(135deg,var(--accent),var(--purple));
   box-shadow: var(--shadow);
+  font-weight:700; color:#000;
 }
 h1{
   margin:0; font-size:28px; letter-spacing:0.6px; text-transform:uppercase; font-weight:800;

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,7 +13,7 @@
   <header>
     <div class="container">
       <a href="{% url 'home' %}" class="brand">
-        <div class="avatar" aria-hidden="true"></div>
+        <div class="avatar" aria-hidden="true">[Ф]</div>
         <h1>Фрактал: школа будущего<span class="cursor">_</span></h1>
       </a>
       <nav class="toolbar">


### PR DESCRIPTION
## Summary
- Show `[Ф]` inside the header avatar for branding
- Use flexbox and text styling to center the avatar initial

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bad460d0d8832db6f818e9dece2d38