### PR TITLE
feat: add bordered signup card to home

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -72,6 +72,11 @@ details[open] .chev { transform: rotate(180deg); }
 .auth-form input { width:100%; padding:8px; border:1px solid var(--border); border-radius:8px; background:var(--bg); color:var(--text); }
 .auth-form .helptext { display:block; margin-top:4px; color:var(--muted); font-size:14px; }
 
+/* Signup form */
+.signup-form { display:grid; gap:12px; }
+.signup-form .grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(180px,1fr)); gap:8px; }
+.signup-form input, .signup-form select { width:100%; padding:8px; border:1px solid var(--border); border-radius:8px; background:var(--bg); color:var(--text); }
+
 /* Dashboard */
 .dashboard-container { display:flex; gap:2rem; }
 .dashboard-sidebar { width:200px; }

--- a/templates/home.html
+++ b/templates/home.html
@@ -5,14 +5,44 @@
 {% block content %}
   <section id="about" class="section">
     <div class="container">
-      <h2 style="margin-top:0">Технологии 2025 на службе образования</h2>
       <div style="text-align:center; text-transform:uppercase; font-weight:800; margin:24px 0;">
         <div>ФИЗИКА | МАТЕМАТИКА | ИНФОРМАТИКА</div>
         <div>ВПР | ОГЭ | ЕГЭ</div>
       </div>
-      <p style="text-align:center; margin:0 0 16px;">Запишитесь на занятия прямо сейчас!</p>
-      <div style="text-align:center; margin-bottom:24px;">
-        <a class="btn accent" href="#signup">Записаться</a>
+      <div class="card" style="max-width:600px; margin:0 auto;">
+        <p class="mb-8" style="text-align:center;">
+          Напишите в Telegram <a href="https://t.me/Shydoo" target="_blank">@Shydoo</a> — ответим сегодня
+        </p>
+        <p class="muted" style="text-align:center; margin-top:0;">
+          Или заполните короткую заявку ниже — мы свяжемся с вами
+        </p>
+        <form action="{% url 'applications:apply' %}" method="post" class="signup-form">
+          {% csrf_token %}
+          <div class="grid">
+            <select name="grade" required>
+              <option value="" selected disabled>Выберите класс</option>
+              <option value="9">9 класс</option>
+              <option value="10">10 класс</option>
+              <option value="11">11 класс</option>
+            </select>
+            <select name="subjects" required>
+              <option value="" selected disabled>Выберите предмет</option>
+              <option value="physics">Физика</option>
+              <option value="math">Математика</option>
+              <option value="informatics">Информатика</option>
+            </select>
+          </div>
+          <input type="text" name="contact_info" placeholder="Телеграм, телефон или email — любой удобный способ связи" required>
+          <input type="text" name="contact_name" placeholder="Как к вам обращаться?" required>
+          <div class="role-toggle">
+            <input type="radio" id="lt-ind" name="lesson_type" value="individual" checked>
+            <label for="lt-ind">Индивидуально</label>
+            <input type="radio" id="lt-group" name="lesson_type" value="group">
+            <label for="lt-group">Группа</label>
+          </div>
+          <div class="muted">Цена: ...</div>
+          <button type="submit" class="btn accent">Записаться</button>
+        </form>
       </div>
       <details class="accordion">
         <summary>


### PR DESCRIPTION
## Summary
- add sign-up card with telegram link and quick form on home page
- style new sign-up form

## Testing
- `python -m pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bbdb203e6c832dafa9a475913080df