### PR TITLE
Wrap about section header in centered container

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -5,8 +5,10 @@
 {% block content %}
   <section id="about" class="section">
     <div class="container">
-      <div style="text-align:center; text-transform:uppercase; font-weight:800; margin:24px 0;">
-        ФИЗИКА | МАТЕМАТИКА | ИНФОРМАТИКА | ВПР | ОГЭ | ЕГЭ
+      <div style="max-width:600px;margin:0 auto;">
+        <div style="text-align:center; text-transform:uppercase; font-weight:800; margin:24px 0;">
+          ФИЗИКА | МАТЕМАТИКА | ИНФОРМАТИКА | ВПР | ОГЭ | ЕГЭ
+        </div>
       </div>
       <div class="card" style="max-width:600px; margin:0 auto;">
         <p class="mb-8" style="text-align:center;">


### PR DESCRIPTION
## Summary
- Wrap the about section headline in a centered container with `max-width:600px` to keep it aligned with the form card

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bc38ec5554832db8e234decb94c9ee