### PR TITLE
Move school info accordion to grades section

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -45,56 +45,57 @@
           <button type="submit" class="btn accent">Записаться</button>
         </form>
       </div>
-      <details class="accordion">
-        <summary>
-          <div class="summary-left">
-            <h3 class="mt-0 mb-0">О школе «Фрактал»</h3>
-          </div>
-          <svg class="chev" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        </summary>
-        <div class="panel">
-          <p class="muted">Школа «Фрактал» — семейный проект репетиторов, сочетающий опыт преподавания и технологии 2025 года.</p>
-
-          <div class="subjects" style="margin-top:12px">
-            <div class="card">
-              <h4>Ермаков Вадим Александрович</h4>
-              <p class="muted">МГТУ им. Баумана (1980), инженер. Учитель и репетитор с 40-летним стажем.</p>
-            </div>
-            <div class="card">
-              <h4>Ермаков Виктор Вадимович</h4>
-              <p class="muted">МГТУ им. Баумана (2013), инженер; МГТУ СТАНКИН (2025), программист машинного обучения. Репетитор с 15-летним стажем.</p>
-            </div>
-            <div class="card">
-              <h4>Ермакова Мария Вадимовна</h4>
-              <p class="muted">МГОУ (2018), физик; РУДН (2020), инженер. Школьный учитель и репетитор с 10-летним стажем.</p>
-            </div>
-          </div>
-
-          <div class="card" style="margin-top:12px">
-            <h4 style="margin:0 0 8px">Наша система обучения</h4>
-            <p class="muted" style="margin:0 0 8px">
-              С 2024 года мы строим процесс обучения, который использует всю мощь современных технологий.
-              С сентября 2025 представляем новую образовательную систему:
-            </p>
-            <ul class="muted" style="margin:0 0 0 18px; display:grid; gap:6px">
-              <li><strong>Уникальные задачи:</strong> задания генерируются автоматически по правилам. У каждого ученика — свои условия (их нет в интернете и у других учеников), при строгом соответствии кодификаторам ФИПИ.</li>
-              <li><strong>Умный уровень нагрузки:</strong> сложность и объём домашки подбираются алгоритмами в зависимости от прогресса.</li>
-              <li><strong>Геймификация прогресса:</strong> достижения оформлены как увлекательная игра, поддерживающая фокус и мотивацию.</li>
-              <li><strong>Нейропомощник:</strong> для быстрых вопросов — ассистент на базе нейросетей, настроенный на учебную программу РФ.</li>
-            </ul>
-            <p style="margin:12px 0 0">
-              <strong>И главное:</strong> в основе остаются занятия с живым преподавателем — гарантия качества и уверенности на экзамене!
-            </p>
-          </div>
-        </div>
-      </details>
     </div>
   </section>
 
-  <section id="grades" class="section">
-    <div class="container">
+    <section id="grades" class="section">
+      <div class="container">
 
-      <!-- 9 класс -->
+        <details class="accordion">
+          <summary>
+            <div class="summary-left">
+              <h3 class="mt-0 mb-0">О школе «Фрактал»</h3>
+            </div>
+            <svg class="chev" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </summary>
+          <div class="panel">
+            <p class="muted">Школа «Фрактал» — семейный проект репетиторов, сочетающий опыт преподавания и технологии 2025 года.</p>
+
+            <div class="subjects" style="margin-top:12px">
+              <div class="card">
+                <h4>Ермаков Вадим Александрович</h4>
+                <p class="muted">МГТУ им. Баумана (1980), инженер. Учитель и репетитор с 40-летним стажем.</p>
+              </div>
+              <div class="card">
+                <h4>Ермаков Виктор Вадимович</h4>
+                <p class="muted">МГТУ им. Баумана (2013), инженер; МГТУ СТАНКИН (2025), программист машинного обучения. Репетитор с 15-летним стажем.</p>
+              </div>
+              <div class="card">
+                <h4>Ермакова Мария Вадимовна</h4>
+                <p class="muted">МГОУ (2018), физик; РУДН (2020), инженер. Школьный учитель и репетитор с 10-летним стажем.</p>
+              </div>
+            </div>
+
+            <div class="card" style="margin-top:12px">
+              <h4 style="margin:0 0 8px">Наша система обучения</h4>
+              <p class="muted" style="margin:0 0 8px">
+                С 2024 года мы строим процесс обучения, который использует всю мощь современных технологий.
+                С сентября 2025 представляем новую образовательную систему:
+              </p>
+              <ul class="muted" style="margin:0 0 0 18px; display:grid; gap:6px">
+                <li><strong>Уникальные задачи:</strong> задания генерируются автоматически по правилам. У каждого ученика — свои условия (их нет в интернете и у других учеников), при строгом соответствии кодификаторам ФИПИ.</li>
+                <li><strong>Умный уровень нагрузки:</strong> сложность и объём домашки подбираются алгоритмами в зависимости от прогресса.</li>
+                <li><strong>Геймификация прогресса:</strong> достижения оформлены как увлекательная игра, поддерживающая фокус и мотивацию.</li>
+                <li><strong>Нейропомощник:</strong> для быстрых вопросов — ассистент на базе нейросетей, настроенный на учебную программу РФ.</li>
+              </ul>
+              <p style="margin:12px 0 0">
+                <strong>И главное:</strong> в основе остаются занятия с живым преподавателем — гарантия качества и уверенности на экзамене!
+              </p>
+            </div>
+          </div>
+        </details>
+
+        <!-- 9 класс -->
       <details class="accordion" open>
         <summary>
           <div class="summary-left">


### PR DESCRIPTION
## Summary
- relocate the "О школе «Фрактал»" accordion from the about section to the grades section just before the 9th grade content

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3b689c40832dbd36ddf20e6a84f9