### PR TITLE
Replace about-school accordion with static section

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -32,22 +32,26 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .hero p { margin: 0 0 20px; color: var(--muted); max-width: 720px; }
 .hero details summary { padding: 0; }
 
-.hero details summary .chev { color: var(--accent); }
 
 .hero details p { margin-top: 12px; }
 .btn-secondary { background: transparent; border: 1px solid var(--border); color: var(--text); }
 
-/* Accordion */
+/* Sections */
 .section { padding: 28px 0; border-bottom: 1px solid var(--border); }
-details.accordion { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 0; overflow: hidden; }
-details + details { margin-top: 12px; }
-summary { list-style: none; cursor: pointer; padding: 18px 18px; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-summary::-webkit-details-marker { display: none }
-.summary-left { display: flex; align-items: center; gap: 12px; }
 .badge { padding: 4px 10px; border-radius: 999px; border: 1px solid var(--border); color: var(--muted); font-size: 12px; }
-.chev { transition: transform .2s ease; }
-details[open] .chev { transform: rotate(180deg); }
 .panel { padding: 16px; border-top: 1px solid var(--border); }
+
+.about-school {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.about-school h3 {
+  margin: 0;
+  padding: 18px;
+}
 
 /* Grid of subjects */
 .subjects { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; }

--- a/templates/home.html
+++ b/templates/home.html
@@ -46,13 +46,8 @@
     <section id="grades" class="section">
       <div class="container">
 
-        <details class="accordion">
-          <summary>
-            <div class="summary-left">
-              <h3 class="mt-0 mb-0">О школе «Фрактал»</h3>
-            </div>
-            <svg class="chev" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          </summary>
+        <div class="about-school">
+          <h3 class="mt-0 mb-0">О школе «Фрактал»</h3>
           <div class="panel">
             <p class="muted">Школа «Фрактал» — семейный проект репетиторов, сочетающий опыт преподавания и технологии 2025 года.</p>
 
@@ -88,7 +83,7 @@
               </p>
             </div>
           </div>
-        </details>
+        </div>
 
 
     </div>


### PR DESCRIPTION
## Summary
- replace `<details>` accordion with `.about-school` container so school info is always visible
- drop accordion-specific CSS and add styles for new `.about-school` block

## Testing
- `python manage.py collectstatic --noinput`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bc4bfbfce0832d93a46ce0f4fe6052