### PR TITLE
feat: add narrow block styling for signup

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -48,6 +48,11 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
   padding: 16px;
 }
 
+.block--narrow {
+  max-width:600px;
+  margin:0 auto;
+}
+
 .block h3 {
   margin-top: 0;
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -5,10 +5,10 @@
 {% block content %}
   <section id="about" class="section">
     <div class="container">
-      <div class="block">
-        <h3 class="section-title">Запись</h3>
+      <div class="block block--narrow">
         <p class="muted mb-8">ФИЗИКА | МАТЕМАТИКА | ИНФОРМАТИКА | ВПР | ОГЭ | ЕГЭ</p>
         <p class="mb-8">Запишитесь через Telegram <a href="https://t.me/Shydoe" target="_blank">@Shydoe</a> или заполните заявку ниже 👇</p>
+        <h3 class="section-title">Запись</h3>
         <form action="{% url 'applications:apply' %}" method="post" class="signup-form">
           {% csrf_token %}
           <div class="grid">


### PR DESCRIPTION
## Summary
- narrow signup block using new `.block--narrow` style
- add "Запись" heading before application form

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bc515526c4832d8921fb5020b4b960