### PR TITLE
Use ApplicationForm on home page

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -7,11 +7,9 @@ class ApplicationForm(forms.ModelForm):
     class Meta:
         model = Application
         fields = [
-            "contact_name",
-            "student_name",
             "grade",
             "subjects",
             "contact_info",
+            "contact_name",
             "lesson_type",
-            "source_offer",
         ]

--- a/fractalschool/views.py
+++ b/fractalschool/views.py
@@ -1,7 +1,14 @@
 from django.views.generic import TemplateView
 
+from applications.forms import ApplicationForm
+
 
 class HomeView(TemplateView):
     """Render the main landing page."""
     template_name = "home.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["form"] = ApplicationForm()
+        return context
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -11,28 +11,8 @@
         <h3 class="section-title">Запись</h3>
         <form action="{% url 'applications:apply' %}" method="post" class="signup-form">
           {% csrf_token %}
-          <div class="grid">
-            <select name="grade" required>
-              <option value="" selected disabled>Выберите класс</option>
-              <option value="9">9 класс</option>
-              <option value="10">10 класс</option>
-              <option value="11">11 класс</option>
-            </select>
-            <select name="subjects" required>
-              <option value="" selected disabled>Выберите предмет</option>
-              <option value="physics">Физика</option>
-              <option value="math">Математика</option>
-              <option value="informatics">Информатика</option>
-            </select>
-          </div>
-          <input type="text" name="contact_info" placeholder="Телеграм, телефон или email — любой удобный способ связи" required>
-          <input type="text" name="contact_name" placeholder="Как к вам обращаться?" required>
-          <div class="role-toggle">
-            <input type="radio" id="lt-ind" name="lesson_type" value="individual" checked>
-            <label for="lt-ind">Индивидуально</label>
-            <input type="radio" id="lt-group" name="lesson_type" value="group">
-            <label for="lt-group">Группа</label>
-          </div>
+          {{ form.non_field_errors }}
+          {{ form.as_p }}
           <div class="muted">Цена: ...</div>
           <button type="submit" class="btn accent">Записаться</button>
         </form>


### PR DESCRIPTION
## Summary
- define ApplicationForm exposing grade, subjects, contact info, contact name and lesson type
- load ApplicationForm in HomeView context
- render form via `form.as_p` on home page

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bc599c3f64832d98edc2727facddd0