### PR TITLE
Add accessible labels to home page form

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -12,7 +12,31 @@
         <form action="{% url 'applications:apply' %}" method="post" class="signup-form">
           {% csrf_token %}
           {{ form.non_field_errors }}
-          {{ form.as_p }}
+          <p>
+            <label for="{{ form.grade.id_for_label }}">{{ form.grade.label }}</label>
+            {{ form.grade }}
+            {{ form.grade.errors }}
+          </p>
+          <p>
+            <label for="{{ form.subjects.id_for_label }}">{{ form.subjects.label }}</label>
+            {{ form.subjects }}
+            {{ form.subjects.errors }}
+          </p>
+          <p>
+            <label for="{{ form.contact_info.id_for_label }}">{{ form.contact_info.label }}</label>
+            {{ form.contact_info }}
+            {{ form.contact_info.errors }}
+          </p>
+          <p>
+            <label for="{{ form.contact_name.id_for_label }}">{{ form.contact_name.label }}</label>
+            {{ form.contact_name }}
+            {{ form.contact_name.errors }}
+          </p>
+          <p>
+            <label for="{{ form.lesson_type.id_for_label }}">{{ form.lesson_type.label }}</label>
+            {{ form.lesson_type }}
+            {{ form.lesson_type.errors }}
+          </p>
           <div class="muted">Цена: ...</div>
           <button type="submit" class="btn accent">Записаться</button>
         </form>


### PR DESCRIPTION
## Summary
- Add explicit labels linked to each field in the sign-up form for better accessibility

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bc71c8c3cc832d8a8433e49c8f8a21