### PR TITLE
Refine homepage blocks with futuristic styling

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -47,12 +47,6 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
   border-radius: 14px;
   padding: 16px;
 }
-
-.block--narrow {
-  max-width:600px;
-  margin:0 auto;
-}
-
 .block--split {
   padding:0;
   overflow:hidden;
@@ -64,6 +58,14 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 
 .block h3 {
   margin-top: 0;
+}
+
+.block--futuristic {
+  background: linear-gradient(135deg, var(--card), color-mix(in srgb, var(--accent) 5%, transparent));
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border));
+  box-shadow:
+    0 0 12px color-mix(in srgb, var(--accent) 25%, transparent),
+    0 0 24px color-mix(in srgb, var(--accent-2) 15%, transparent);
 }
 
 .section-title {

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <section id="about" class="section">
   <div class="container">
-    <div class="block block--narrow">
+    <div class="block block--futuristic">
       <p class="muted mb-8">{% trans "ФИЗИКА | МАТЕМАТИКА | ИНФОРМАТИКА | ВПР | ОГЭ | ЕГЭ" %}</p>
         <p class="mb-8">{% blocktrans trimmed %}Запишитесь через Telegram <a href="https://t.me/Shydoe" target="_blank">@Shydoe</a> или заполните заявку ниже 👇{% endblocktrans %}</p>
         <h3 class="section-title">{% trans "Запись" %}</h3>

--- a/templates/partials/teachers.html
+++ b/templates/partials/teachers.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <section id="grades" class="section">
   <div class="container">
-    <div class="block block--split">
+    <div class="block block--split block--futuristic">
       <div class="panel">
         <h3 class="mt-0 mb-0">{% trans "О школе «Фрактал»" %}</h3>
       </div>

--- a/templates/partials/testimonials.html
+++ b/templates/partials/testimonials.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <section class="section">
   <div class="container">
-    <div class="block">
+    <div class="block block--futuristic">
         <h3 class="section-title">{% trans "Отзывы" %}</h3>
       <div class="testimonials">
           <div class="quote">{% blocktrans trimmed %}«Виктор, спасибо Вам огромное!!! Я вообще в шоке!!! Я Вам бесконечно благодарен!!!».<br><strong>— Дмитрий, 100 баллов на ЕГЭ по информатике</strong>{% endblocktrans %}</div>


### PR DESCRIPTION
## Summary
- Align homepage intro block width with other sections
- Apply new neon-style design to homepage blocks

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bc76b204e4832da0052816d51e8c35