### PR TITLE
Ensure partial blocks start with section titles

### DIFF
--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -2,9 +2,9 @@
 <section id="about" class="section">
   <div class="container">
     <div class="block block--futuristic">
+      <h3 class="section-title">{% trans "Запись" %}</h3>
       <p class="muted mb-8">{% trans "ФИЗИКА | МАТЕМАТИКА | ИНФОРМАТИКА | ВПР | ОГЭ | ЕГЭ" %}</p>
-        <p class="mb-8">{% blocktrans trimmed %}Запишитесь через Telegram <a href="https://t.me/Shydoe" target="_blank">@Shydoe</a> или заполните заявку ниже 👇{% endblocktrans %}</p>
-        <h3 class="section-title">{% trans "Запись" %}</h3>
+      <p class="mb-8">{% blocktrans trimmed %}Запишитесь через Telegram <a href="https://t.me/Shydoe" target="_blank">@Shydoe</a> или заполните заявку ниже 👇{% endblocktrans %}</p>
       <form action="{% url 'applications:apply' %}" method="post" class="signup-form">
         {% csrf_token %}
         {{ form.non_field_errors }}

--- a/templates/partials/teachers.html
+++ b/templates/partials/teachers.html
@@ -2,9 +2,7 @@
 <section id="grades" class="section">
   <div class="container">
     <div class="block block--split block--futuristic">
-      <div class="panel">
-        <h3 class="mt-0 mb-0">{% trans "О школе «Фрактал»" %}</h3>
-      </div>
+      <h3 class="section-title">{% trans "О школе «Фрактал»" %}</h3>
       <div class="panel">
         <p class="muted">{% blocktrans trimmed %}Школа «Фрактал» — семейный проект репетиторов, сочетающий опыт преподавания и технологии 2025 года.{% endblocktrans %}</p>
 


### PR DESCRIPTION
## Summary
- Move the "Запись" title to the top of the about block
- Remove extra panel wrapper in the teachers block and add its title at the top
- Confirm testimonials already begin with a section title for consistency

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bc7e4bbb20832d8af577f91364ff6e