### PR TITLE
style: adjust reviews block background

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -81,7 +81,7 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .pill:hover { border-color: color-mix(in srgb, var(--accent) 60%, var(--border)); }
 
 /* Testimonials */
-.reviews-block { background: var(--bg); }
+.reviews-block { background: var(--card); }
 .testimonials { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px,1fr)); gap: 12px; }
 .quote { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 16px; color: var(--muted); }
 .quote strong { color: var(--text); }


### PR DESCRIPTION
## Summary
- highlight testimonials by using `var(--card)` background for `.reviews-block`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bc86e34250832dac6f255bef2ec942