### PR TITLE
Simplify teachers section markup

### DIFF
--- a/static/css/cyber.css
+++ b/static/css/cyber.css
@@ -55,10 +55,6 @@ section{margin:28px 0;}
 .fill{position:absolute; inset:0 auto 0 0; width:0%; background:linear-gradient(90deg, rgba(0,255,156,.9), rgba(156,107,255,.85)); box-shadow: inset 0 0 12px rgba(0,0,0,.35), 0 0 18px rgba(0,255,156,.35);
   transition:width .35s ease;}
 
-.panel{
-  border:1px solid var(--outline); border-radius:16px; background:linear-gradient(180deg,#0b1210,#09110e);
-  padding:16px; box-shadow: var(--shadow);
-}
 .controls{display:grid; gap:10px; grid-template-columns:repeat(1, minmax(0,1fr));}
 @media (min-width:820px){ .controls{ grid-template-columns:repeat(3, minmax(0,1fr)); }}
 .ctrl{display:flex; align-items:center; gap:10px; border:1px dashed var(--outline); padding:10px; border-radius:12px;}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -39,21 +39,12 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 /* Sections */
 .section { padding: 28px 0; border-bottom: 1px solid var(--border); }
 .badge { padding: 4px 10px; border-radius: 999px; border: 1px solid var(--border); color: var(--muted); font-size: 12px; }
-.panel { padding: 16px; border-top: 1px solid var(--border); }
 
 .block {
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 14px;
   padding: 16px;
-}
-.block--split {
-  padding:0;
-  overflow:hidden;
-}
-
-.block--split .panel:first-child {
-  border-top:0;
 }
 
 .block h3 {

--- a/templates/partials/teachers.html
+++ b/templates/partials/teachers.html
@@ -1,37 +1,35 @@
 {% load i18n %}
 <section id="grades" class="section">
   <div class="container">
-    <div class="block block--split block--futuristic">
+    <div class="block block--futuristic">
       <h3 class="section-title">{% trans "О школе «Фрактал»" %}</h3>
-      <div class="panel">
-        <p class="muted">{% blocktrans trimmed %}Школа «Фрактал» — семейный проект репетиторов, сочетающий опыт преподавания и технологии 2025 года.{% endblocktrans %}</p>
+      <p class="muted">{% blocktrans trimmed %}Школа «Фрактал» — семейный проект репетиторов, сочетающий опыт преподавания и технологии 2025 года.{% endblocktrans %}</p>
 
-        <div class="subjects mt-12">
-          <div class="card">
-            <h4>{% trans "Ермаков Вадим Александрович" %}</h4>
-            <p class="muted">{% trans "МГТУ им. Баумана (1980), инженер. Учитель и репетитор с 40-летним стажем." %}</p>
-          </div>
-          <div class="card">
-            <h4>{% trans "Ермаков Виктор Вадимович" %}</h4>
-            <p class="muted">{% blocktrans trimmed %}МГТУ им. Баумана (2013), инженер; МГТУ СТАНКИН (2025), программист машинного обучения. Репетитор с 15-летним стажем.{% endblocktrans %}</p>
-          </div>
-          <div class="card">
-            <h4>{% trans "Ермакова Мария Вадимовна" %}</h4>
-            <p class="muted">{% blocktrans trimmed %}МГОУ (2018), физик; РУДН (2020), инженер. Школьный учитель и репетитор с 10-летним стажем.{% endblocktrans %}</p>
-          </div>
+      <div class="subjects mt-12">
+        <div class="card">
+          <h4>{% trans "Ермаков Вадим Александрович" %}</h4>
+          <p class="muted">{% trans "МГТУ им. Баумана (1980), инженер. Учитель и репетитор с 40-летним стажем." %}</p>
         </div>
+        <div class="card">
+          <h4>{% trans "Ермаков Виктор Вадимович" %}</h4>
+          <p class="muted">{% blocktrans trimmed %}МГТУ им. Баумана (2013), инженер; МГТУ СТАНКИН (2025), программист машинного обучения. Репетитор с 15-летним стажем.{% endblocktrans %}</p>
+        </div>
+        <div class="card">
+          <h4>{% trans "Ермакова Мария Вадимовна" %}</h4>
+          <p class="muted">{% blocktrans trimmed %}МГОУ (2018), физик; РУДН (2020), инженер. Школьный учитель и репетитор с 10-летним стажем.{% endblocktrans %}</p>
+        </div>
+      </div>
 
-          <div class="card mt-12">
-            <h4 class="mt-0 mb-8">{% trans "Наша система обучения" %}</h4>
-            <p class="muted mt-0 mb-8">{% blocktrans trimmed %}С 2024 года мы строим процесс обучения, который использует всю мощь современных технологий. С сентября 2025 представляем новую образовательную систему:{% endblocktrans %}</p>
-            <ul class="muted feature-list">
-              <li>{% blocktrans trimmed %}<strong>Уникальные задачи:</strong> задания генерируются автоматически по правилам. У каждого ученика — свои условия (их нет в интернете и у других учеников), при строгом соответствии кодификаторам ФИПИ.{% endblocktrans %}</li>
-              <li>{% blocktrans trimmed %}<strong>Умный уровень нагрузки:</strong> сложность и объём домашки подбираются алгоритмами в зависимости от прогресса.{% endblocktrans %}</li>
-              <li>{% blocktrans trimmed %}<strong>Геймификация прогресса:</strong> достижения оформлены как увлекательная игра, поддерживающая фокус и мотивацию.{% endblocktrans %}</li>
-              <li>{% blocktrans trimmed %}<strong>Нейропомощник:</strong> для быстрых вопросов — ассистент на базе нейросетей, настроенный на учебную программу РФ.{% endblocktrans %}</li>
-            </ul>
-            <p class="mt-12">{% blocktrans trimmed %}<strong>И главное:</strong> в основе остаются занятия с живым преподавателем — гарантия качества и уверенности на экзамене!{% endblocktrans %}</p>
-          </div>
+      <div class="card mt-12">
+        <h4 class="mt-0 mb-8">{% trans "Наша система обучения" %}</h4>
+        <p class="muted mt-0 mb-8">{% blocktrans trimmed %}С 2024 года мы строим процесс обучения, который использует всю мощь современных технологий. С сентября 2025 представляем новую образовательную систему:{% endblocktrans %}</p>
+        <ul class="muted feature-list">
+          <li>{% blocktrans trimmed %}<strong>Уникальные задачи:</strong> задания генерируются автоматически по правилам. У каждого ученика — свои условия (их нет в интернете и у других учеников), при строгом соответствии кодификаторам ФИПИ.{% endblocktrans %}</li>
+          <li>{% blocktrans trimmed %}<strong>Умный уровень нагрузки:</strong> сложность и объём домашки подбираются алгоритмами в зависимости от прогресса.{% endblocktrans %}</li>
+          <li>{% blocktrans trimmed %}<strong>Геймификация прогресса:</strong> достижения оформлены как увлекательная игра, поддерживающая фокус и мотивацию.{% endblocktrans %}</li>
+          <li>{% blocktrans trimmed %}<strong>Нейропомощник:</strong> для быстрых вопросов — ассистент на базе нейросетей, настроенный на учебную программу РФ.{% endblocktrans %}</li>
+        </ul>
+        <p class="mt-12">{% blocktrans trimmed %}<strong>И главное:</strong> в основе остаются занятия с живым преподавателем — гарантия качества и уверенности на экзамене!{% endblocktrans %}</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- remove unused `.panel` wrapper and `block--split` class in teachers section
- delete related CSS rules

## Testing
- `python -m pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8d688a34832d9aea268f7301daea