### PR TITLE
Implement separate grade and subject dropdowns on signup form

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -1,15 +1,43 @@
 from django import forms
 
-from .models import Application
+from .models import Application, Subject
 
 
 class ApplicationForm(forms.ModelForm):
+    grade = forms.TypedChoiceField(
+        coerce=int,
+        choices=[(9, "9"), (10, "10"), (11, "11")],
+        label="",
+    )
+    subject1 = forms.ModelChoiceField(
+        queryset=Subject.objects.all(),
+        label="",
+    )
+    subject2 = forms.ModelChoiceField(
+        queryset=Subject.objects.all(),
+        required=False,
+        label="",
+    )
+
+
     class Meta:
         model = Application
         fields = [
             "grade",
-            "subjects",
+            "subject1",
+            "subject2",
             "contact_info",
             "contact_name",
             "lesson_type",
         ]
+
+    def save(self, commit: bool = True) -> Application:  # type: ignore[override]
+        application = super().save(commit=False)
+        if commit:
+            application.save()
+            subjects = [self.cleaned_data["subject1"]]
+            subject2 = self.cleaned_data.get("subject2")
+            if subject2:
+                subjects.append(subject2)
+            application.subjects.set(subjects)
+        return application

--- a/applications/tests.py
+++ b/applications/tests.py
@@ -14,11 +14,12 @@ class ApplicationTests(TestCase):
         data = {
             "contact_name": "Parent",
             "student_name": "Student",
-            "grade": 5,
-            "subjects": [self.subject_math.id, self.subject_physics.id],
+            "grade": 9,
+            "subject1": self.subject_math.id,
+            "subject2": self.subject_physics.id,
             "contact_info": "email@example.com",
             "lesson_type": "individual",
-            "source_offer": "math-5",
+            "source_offer": "math-9",
         }
         response = self.client.post(reverse("applications:apply"), data)
         self.assertEqual(response.status_code, 302)

--- a/applications/views.py
+++ b/applications/views.py
@@ -20,7 +20,7 @@ class ApplicationCreateView(FormView):
             slug, *rest = source_offer.split("-")
             try:
                 subject = Subject.objects.get(slug=slug)
-                initial["subjects"] = [subject.pk]
+                initial["subject1"] = subject.pk
             except Subject.DoesNotExist:
                 pass
             if rest and rest[0].isdigit():

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -8,16 +8,36 @@
       <form action="{% url 'applications:apply' %}" method="post" class="signup-form">
         {% csrf_token %}
         {{ form.non_field_errors }}
-        <p>
-          <label for="{{ form.grade.id_for_label }}">{{ form.grade.label }}</label>
-          {{ form.grade }}
-          {{ form.grade.errors }}
-        </p>
-        <p>
-          <label for="{{ form.subjects.id_for_label }}">{{ form.subjects.label }}</label>
-          {{ form.subjects }}
-          {{ form.subjects.errors }}
-        </p>
+        <div class="grid">
+          <div>
+            <select name="{{ form.grade.html_name }}" id="{{ form.grade.id_for_label }}">
+              <option value="" selected disabled>{% trans "выберите класс" %}</option>
+              {% for value, label in form.fields.grade.choices %}
+                <option value="{{ value }}" {% if form.grade.value|stringformat:'s' == value|stringformat:'s' %}selected{% endif %}>{{ label }}</option>
+              {% endfor %}
+            </select>
+            {{ form.grade.errors }}
+          </div>
+          <div>
+            <select name="{{ form.subject1.html_name }}" id="{{ form.subject1.id_for_label }}">
+              <option value="" selected disabled>{% trans "выберите предмет" %}</option>
+              {% for subject in form.fields.subject1.queryset %}
+                <option value="{{ subject.pk }}" {% if form.subject1.value|stringformat:'s' == subject.pk|stringformat:'s' %}selected{% endif %}>{{ subject.name }}</option>
+              {% endfor %}
+            </select>
+            {{ form.subject1.errors }}
+          </div>
+          <div>
+            <select name="{{ form.subject2.html_name }}" id="{{ form.subject2.id_for_label }}">
+              <option value="" selected disabled>{% trans "выберите второй предмет" %}</option>
+              {% for subject in form.fields.subject2.queryset %}
+                <option value="{{ subject.pk }}" {% if form.subject2.value|stringformat:'s' == subject.pk|stringformat:'s' %}selected{% endif %}>{{ subject.name }}</option>
+              {% endfor %}
+              <option value="">{% trans "- не нужен -" %}</option>
+            </select>
+            {{ form.subject2.errors }}
+          </div>
+        </div>
         <p>
           <label for="{{ form.contact_info.id_for_label }}">{{ form.contact_info.label }}</label>
           {{ form.contact_info }}


### PR DESCRIPTION
## Summary
- Split application subjects into two separate dropdowns and restrict grade to 9-11
- Update application view and main page template to render new selects in a row
- Adjust tests for new form API

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bc911485b8832db179e11a62aa7dc5