### PR TITLE
Style lesson format toggle on home page

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from .models import Application
 from subjects.models import Subject
@@ -31,6 +32,9 @@ class ApplicationForm(forms.ModelForm):
             "contact_name",
             "lesson_type",
         ]
+        labels = {
+            "lesson_type": _("Формат"),
+        }
 
     def save(self, commit: bool = True) -> Application:  # type: ignore[override]
         application = super().save(commit=False)

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -114,6 +114,14 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .role-toggle label { flex:1; text-align:center; padding:10px 0; border:1px solid var(--border); border-radius:10px; background:var(--card); cursor:pointer; }
 .role-toggle input:checked + label { background:var(--accent); color:#001420; border-color:color-mix(in srgb, var(--accent) 70%, black); }
 
+.lesson-type-field { display:flex; align-items:center; gap:8px; }
+.format-toggle { display:inline-flex; }
+.format-toggle input { display:none; }
+.format-toggle label { padding:8px 12px; border:1px solid var(--border); background:var(--card); cursor:pointer; }
+.format-toggle label:first-of-type { border-top-left-radius:10px; border-bottom-left-radius:10px; }
+.format-toggle label:last-of-type { border-top-right-radius:10px; border-bottom-right-radius:10px; margin-left:-1px; }
+.format-toggle input:checked + label { background:var(--accent); color:#001420; border-color:color-mix(in srgb, var(--accent) 70%, black); }
+
 /* Utility */
 .sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
 

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -48,9 +48,20 @@
           {{ form.contact_name }}
           {{ form.contact_name.errors }}
         </p>
-        <p>
-          <label for="{{ form.lesson_type.id_for_label }}">{{ form.lesson_type.label }}</label>
-          {{ form.lesson_type }}
+        <p class="lesson-type-field">
+          <span class="lesson-type-label">{{ form.lesson_type.label }}:</span>
+          <span class="format-toggle">
+            {% for value, label in form.fields.lesson_type.choices %}
+              <input
+                type="radio"
+                id="id_{{ form.lesson_type.html_name }}_{{ forloop.counter }}"
+                name="{{ form.lesson_type.html_name }}"
+                value="{{ value }}"
+                {% if form.lesson_type.value|stringformat:'s' == value|stringformat:'s' %}checked{% endif %}
+              />
+              <label for="id_{{ form.lesson_type.html_name }}_{{ forloop.counter }}">{{ label }}</label>
+            {% endfor %}
+          </span>
           {{ form.lesson_type.errors }}
         </p>
         <div class="muted">{% trans "Цена: ..." %}</div>


### PR DESCRIPTION
## Summary
- Add Russian label and translation support for lesson format field
- Render lesson format choice as segmented toggle on home page
- Style new toggle control in main stylesheet

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bccc8e8b64832db1618965040a055a