### PR TITLE
Fix lesson format toggle and localize options

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -1,12 +1,13 @@
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from subjects.models import Subject
 
 
 class Application(models.Model):
     class LessonType(models.TextChoices):
-        INDIVIDUAL = "individual", "Individual"
-        GROUP = "group", "Group"
+        INDIVIDUAL = "individual", _("Индивидуально")
+        GROUP = "group", _("Группа")
 
     class Status(models.TextChoices):
         NEW = "new", "New"

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -115,12 +115,29 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .role-toggle input:checked + label { background:var(--accent); color:#001420; border-color:color-mix(in srgb, var(--accent) 70%, black); }
 
 .lesson-type-field { display:flex; align-items:center; gap:8px; }
-.format-toggle { display:inline-flex; }
-.format-toggle input { display:none; }
-.format-toggle label { padding:8px 12px; border:1px solid var(--border); background:var(--card); cursor:pointer; }
-.format-toggle label:first-of-type { border-top-left-radius:10px; border-bottom-left-radius:10px; }
-.format-toggle label:last-of-type { border-top-right-radius:10px; border-bottom-right-radius:10px; margin-left:-1px; }
-.format-toggle input:checked + label { background:var(--accent); color:#001420; border-color:color-mix(in srgb, var(--accent) 70%, black); }
+.format-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.format-toggle input {
+  display: none;
+}
+.format-toggle input + label {
+  padding: 8px 12px;
+  background: var(--card);
+  cursor: pointer;
+  border-right: 1px solid var(--border);
+}
+.format-toggle input:last-of-type + label {
+  border-right: none;
+}
+.format-toggle input:checked + label {
+  background: var(--accent);
+  color: #001420;
+  border-color: color-mix(in srgb, var(--accent) 70%, black);
+}
 
 /* Utility */
 .sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -50,18 +50,19 @@
         </p>
         <p class="lesson-type-field">
           <span class="lesson-type-label">{{ form.lesson_type.label }}:</span>
+          {% spaceless %}
           <span class="format-toggle">
             {% for value, label in form.fields.lesson_type.choices %}
-              <input
-                type="radio"
-                id="id_{{ form.lesson_type.html_name }}_{{ forloop.counter }}"
-                name="{{ form.lesson_type.html_name }}"
-                value="{{ value }}"
-                {% if form.lesson_type.value|stringformat:'s' == value|stringformat:'s' %}checked{% endif %}
-              />
-              <label for="id_{{ form.lesson_type.html_name }}_{{ forloop.counter }}">{{ label }}</label>
+            <input
+              type="radio"
+              id="id_{{ form.lesson_type.html_name }}_{{ forloop.counter }}"
+              name="{{ form.lesson_type.html_name }}"
+              value="{{ value }}"
+              {% if form.lesson_type.value|stringformat:'s' == value|stringformat:'s' %}checked{% endif %}
+            /><label for="id_{{ form.lesson_type.html_name }}_{{ forloop.counter }}">{{ label }}</label>
             {% endfor %}
           </span>
+          {% endspaceless %}
           {{ form.lesson_type.errors }}
         </p>
         <div class="muted">{% trans "Цена: ..." %}</div>


### PR DESCRIPTION
## Summary
- style the lesson format toggle like a segmented control
- translate lesson format options to Russian
- remove stray whitespace in lesson format toggle template

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bcce4a2b24832da4ccc6209325d7f3