### PR TITLE
Add lesson format switch on homepage

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -115,28 +115,25 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .role-toggle input:checked + label { background:var(--accent); color:#001420; border-color:color-mix(in srgb, var(--accent) 70%, black); }
 
 .lesson-type-field { display:flex; align-items:center; gap:8px; }
-.format-toggle {
+.switch .seg {
   display: inline-flex;
   border: 1px solid var(--border);
   border-radius: 10px;
   overflow: hidden;
 }
-.format-toggle input {
-  display: none;
-}
-.format-toggle input + label {
+.switch .seg button {
   padding: 8px 12px;
   background: var(--card);
   cursor: pointer;
+  border: none;
   border-right: 1px solid var(--border);
 }
-.format-toggle input:last-of-type + label {
+.switch .seg button:last-child {
   border-right: none;
 }
-.format-toggle input:checked + label {
+.switch .seg button.active {
   background: var(--accent);
   color: #001420;
-  border-color: color-mix(in srgb, var(--accent) 70%, black);
 }
 
 /* Utility */

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,3 +4,20 @@ document.addEventListener('click', (e) => {
   const offer = btn.getAttribute('data-offer');
   alert('Офер: ' + offer + '\nЗдесь можно открыть форму записи и передать код оффера.');
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+  const seg = document.querySelector('.seg[role="tablist"]');
+  const input = document.getElementById('id_lesson_type');
+  if (!seg || !input) return;
+  seg.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-mode]');
+    if (!btn) return;
+    const mode = btn.getAttribute('data-mode');
+    input.value = mode;
+    seg.querySelectorAll('button[data-mode]').forEach((b) => {
+      const active = b === btn;
+      b.classList.toggle('active', active);
+      b.setAttribute('aria-selected', active ? 'true' : 'false');
+    });
+  });
+});

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -48,23 +48,27 @@
           {{ form.contact_name }}
           {{ form.contact_name.errors }}
         </p>
+        {% with current=form.lesson_type.value|default:form.fields.lesson_type.choices.0.0 %}
         <p class="lesson-type-field">
-          <span class="lesson-type-label">{{ form.lesson_type.label }}:</span>
-          {% spaceless %}
-          <span class="format-toggle">
-            {% for value, label in form.fields.lesson_type.choices %}
-            <input
-              type="radio"
-              id="id_{{ form.lesson_type.html_name }}_{{ forloop.counter }}"
-              name="{{ form.lesson_type.html_name }}"
-              value="{{ value }}"
-              {% if form.lesson_type.value|stringformat:'s' == value|stringformat:'s' %}checked{% endif %}
-            /><label for="id_{{ form.lesson_type.html_name }}_{{ forloop.counter }}">{{ label }}</label>
-            {% endfor %}
-          </span>
-          {% endspaceless %}
+          <div class="switch">
+            <span class="muted">{{ form.lesson_type.label }}:</span>
+            <div class="seg" role="tablist" aria-label="{{ form.lesson_type.label }}">
+              {% for value, label in form.fields.lesson_type.choices %}
+              <button
+                type="button"
+                id="mode-{{ value }}"
+                data-mode="{{ value }}"
+                role="tab"
+                aria-selected="{% if current == value %}true{% else %}false{% endif %}"
+                class="{% if current == value %}active{% endif %}"
+              >{{ label }}</button>
+              {% endfor %}
+            </div>
+          </div>
+          <input type="hidden" name="{{ form.lesson_type.html_name }}" id="{{ form.lesson_type.id_for_label }}" value="{{ current }}" />
           {{ form.lesson_type.errors }}
         </p>
+        {% endwith %}
         <div class="muted">{% trans "Цена: ..." %}</div>
         <button type="submit" class="btn accent">{% trans "Записаться" %}</button>
       </form>


### PR DESCRIPTION
## Summary
- replace lesson format radio inputs with segmented button switch on the main signup form
- style switch component and add JavaScript to update hidden field and active state

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bd336017e0832da0afc854ff6a1f15