### PR TITLE
Add lesson format switch on home page

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -138,6 +138,7 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 
 /* Utility */
 .sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
 
 /* Spacing utilities */
 .mt-0 { margin-top: 0; }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -5,19 +5,27 @@ document.addEventListener('click', (e) => {
   alert('Офер: ' + offer + '\nЗдесь можно открыть форму записи и передать код оффера.');
 });
 
-document.addEventListener('DOMContentLoaded', () => {
-  const seg = document.querySelector('.seg[role="tablist"]');
+function setMode(mode) {
+  const individualBtn = document.getElementById('mode-individual');
+  const groupBtn = document.getElementById('mode-group');
   const input = document.getElementById('id_lesson_type');
-  if (!seg || !input) return;
-  seg.addEventListener('click', (e) => {
-    const btn = e.target.closest('button[data-mode]');
-    if (!btn) return;
-    const mode = btn.getAttribute('data-mode');
-    input.value = mode;
-    seg.querySelectorAll('button[data-mode]').forEach((b) => {
-      const active = b === btn;
-      b.classList.toggle('active', active);
-      b.setAttribute('aria-selected', active ? 'true' : 'false');
-    });
-  });
+  if (!individualBtn || !groupBtn || !input) return;
+
+  if (mode === 'individual') {
+    individualBtn.classList.add('active');
+    individualBtn.setAttribute('aria-selected', 'true');
+    groupBtn.classList.remove('active');
+    groupBtn.setAttribute('aria-selected', 'false');
+  } else {
+    groupBtn.classList.add('active');
+    groupBtn.setAttribute('aria-selected', 'true');
+    individualBtn.classList.remove('active');
+    individualBtn.setAttribute('aria-selected', 'false');
+  }
+
+  input.value = mode;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setMode('group');
 });

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -48,27 +48,20 @@
           {{ form.contact_name }}
           {{ form.contact_name.errors }}
         </p>
-        {% with current=form.lesson_type.value|default:form.fields.lesson_type.choices.0.0 %}
-        <p class="lesson-type-field">
-          <div class="switch">
-            <span class="muted">{{ form.lesson_type.label }}:</span>
-            <div class="seg" role="tablist" aria-label="{{ form.lesson_type.label }}">
-              {% for value, label in form.fields.lesson_type.choices %}
-              <button
-                type="button"
-                id="mode-{{ value }}"
-                data-mode="{{ value }}"
-                role="tab"
-                aria-selected="{% if current == value %}true{% else %}false{% endif %}"
-                class="{% if current == value %}active{% endif %}"
-              >{{ label }}</button>
-              {% endfor %}
+        <div class="lesson-type-field">
+          <div>
+            <label class="sr-only">Формат занятий</label>
+            <div class="switch">
+              <span class="muted">Формат:</span>
+              <div class="seg" role="tablist" aria-label="Формат занятий">
+                <button type="button" id="mode-individual" class="active" role="tab" aria-selected="false" onclick="setMode('individual')">Индивидуальный</button>
+                <button type="button" id="mode-group" role="tab" aria-selected="true" onclick="setMode('group')">Групповой</button>
+              </div>
             </div>
           </div>
-          <input type="hidden" name="{{ form.lesson_type.html_name }}" id="{{ form.lesson_type.id_for_label }}" value="{{ current }}" />
+          <input type="hidden" name="{{ form.lesson_type.html_name }}" id="{{ form.lesson_type.id_for_label }}" value="group" />
           {{ form.lesson_type.errors }}
-        </p>
-        {% endwith %}
+        </div>
         <div class="muted">{% trans "Цена: ..." %}</div>
         <button type="submit" class="btn accent">{% trans "Записаться" %}</button>
       </form>


### PR DESCRIPTION
## Summary
- add lesson format toggle matching required markup
- expose `setMode` JS helper for switching modes
- include screen-reader-only utility style

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bd355f003c832da75cee782089933b