### PR TITLE
Remove contact info label on homepage

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -34,6 +34,12 @@ class ApplicationForm(forms.ModelForm):
         ]
         labels = {
             "lesson_type": _("Формат"),
+            "contact_info": "",
+        }
+        widgets = {
+            "contact_info": forms.Textarea(
+                attrs={"placeholder": _("как с вами связаться")}
+            ),
         }
 
     def save(self, commit: bool = True) -> Application:  # type: ignore[override]

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -39,7 +39,6 @@
           </div>
         </div>
         <p>
-          <label for="{{ form.contact_info.id_for_label }}">{{ form.contact_info.label }}</label>
           {{ form.contact_info }}
           {{ form.contact_info.errors }}
         </p>


### PR DESCRIPTION
## Summary
- remove "Contact info" label on main page application form
- add placeholder asking "как с вами связаться" for contact field

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bd37d5e598832da6e72fae559d0a6c