### PR TITLE
Use placeholder for contact name field

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -35,10 +35,14 @@ class ApplicationForm(forms.ModelForm):
         labels = {
             "lesson_type": _("Формат"),
             "contact_info": "",
+            "contact_name": "",
         }
         widgets = {
             "contact_info": forms.Textarea(
                 attrs={"placeholder": _("как с вами связаться")}
+            ),
+            "contact_name": forms.TextInput(
+                attrs={"placeholder": _("Ваше имя")}
             ),
         }
 

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -43,7 +43,6 @@
           {{ form.contact_info.errors }}
         </p>
         <p>
-          <label for="{{ form.contact_name.id_for_label }}">{{ form.contact_name.label }}</label>
           {{ form.contact_name }}
           {{ form.contact_name.errors }}
         </p>


### PR DESCRIPTION
## Summary
- remove hardcoded contact name label and supply 'Ваше имя' placeholder
- drop contact name label from about page template

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bd3991020c832d83f157c5f6a1df07