### PR TITLE
feat: adjust signup form layout

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -39,7 +39,7 @@ class ApplicationForm(forms.ModelForm):
         }
         widgets = {
             "contact_info": forms.Textarea(
-                attrs={"placeholder": _("как с вами связаться")}
+                attrs={"placeholder": _("Ваши контакты и пожелания")}
             ),
             "contact_name": forms.TextInput(
                 attrs={"placeholder": _("Ваше имя")}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -95,6 +95,10 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .signup-form input, .signup-form select, .signup-form textarea { width:100%; padding:8px; border:1px solid var(--border); border-radius:8px; background:var(--bg); color:var(--text); }
 .signup-form textarea { height:44px; resize:vertical; }
 
+/* Name and format row */
+.name-format-row { display:flex; align-items:center; gap:12px; }
+.name-format-row .name-field { flex:1; }
+
 /* Dashboard */
 .dashboard-container { display:flex; gap:2rem; }
 .dashboard-sidebar { width:200px; }

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -42,23 +42,25 @@
           {{ form.contact_info }}
           {{ form.contact_info.errors }}
         </p>
-        <p>
-          {{ form.contact_name }}
-          {{ form.contact_name.errors }}
-        </p>
-        <div class="lesson-type-field">
-          <div>
-            <label class="sr-only">Формат занятий</label>
-            <div class="switch">
-              <span class="muted">Формат:</span>
-              <div class="seg" role="tablist" aria-label="Формат занятий">
-                <button type="button" id="mode-individual" class="active" role="tab" aria-selected="false" onclick="setMode('individual')">Индивидуальный</button>
-                <button type="button" id="mode-group" role="tab" aria-selected="true" onclick="setMode('group')">Групповой</button>
+        <div class="name-format-row">
+          <div class="name-field">
+            {{ form.contact_name }}
+            {{ form.contact_name.errors }}
+          </div>
+          <div class="lesson-type-field">
+            <div>
+              <label class="sr-only">Формат занятий</label>
+              <div class="switch">
+                <span class="muted">Формат:</span>
+                <div class="seg" role="tablist" aria-label="Формат занятий">
+                  <button type="button" id="mode-individual" class="active" role="tab" aria-selected="false" onclick="setMode('individual')">Индивидуальный</button>
+                  <button type="button" id="mode-group" role="tab" aria-selected="true" onclick="setMode('group')">Групповой</button>
+                </div>
               </div>
             </div>
+            <input type="hidden" name="{{ form.lesson_type.html_name }}" id="{{ form.lesson_type.id_for_label }}" value="group" />
+            {{ form.lesson_type.errors }}
           </div>
-          <input type="hidden" name="{{ form.lesson_type.html_name }}" id="{{ form.lesson_type.id_for_label }}" value="group" />
-          {{ form.lesson_type.errors }}
         </div>
         <div class="muted">{% trans "Цена: ..." %}</div>
         <button type="submit" class="btn accent">{% trans "Записаться" %}</button>


### PR DESCRIPTION
## Summary
- replace contact info placeholder on home page
- align name field with format switch in one row

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bd3ce33670832d8cd6f5b21211b0a1