### PR TITLE
Add application price calculation

### DIFF
--- a/applications/utils.py
+++ b/applications/utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Dict
+
+INDIVIDUAL_PRICE_PER_SUBJECT = 4000
+GROUP_PRICE_PER_SUBJECT = 2500
+
+
+def get_application_price(lesson_type: str, subjects_count: int) -> str:
+    """Return price string for application depending on lesson type and subjects count.
+
+    The price is calculated as a simple multiplication of the number of
+    subjects by a predefined price per subject for each lesson type.
+    The result is formatted with a trailing ``"₽/мес"`` suffix.
+    """
+    if subjects_count <= 0:
+        return ""
+    price_per_subject: Dict[str, int] = {
+        "individual": INDIVIDUAL_PRICE_PER_SUBJECT,
+        "group": GROUP_PRICE_PER_SUBJECT,
+    }
+    per_subject = price_per_subject.get(lesson_type)
+    if per_subject is None:
+        return ""
+    total = per_subject * subjects_count
+    # Format number with spaces as thousand separators
+    total_str = f"{total:,}".replace(",", " ")
+    return f"{total_str} ₽/мес"

--- a/applications/views.py
+++ b/applications/views.py
@@ -1,10 +1,11 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from django.urls import reverse_lazy
 from django.views.generic import FormView
 
 from .forms import ApplicationForm
 from subjects.models import Subject
+from .utils import get_application_price
 
 
 class ApplicationCreateView(FormView):
@@ -30,3 +31,20 @@ class ApplicationCreateView(FormView):
     def form_valid(self, form: ApplicationForm) -> Any:  # type: ignore[override]
         form.save()
         return super().form_valid(form)
+
+    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:  # type: ignore[override]
+        context = super().get_context_data(**kwargs)
+        form: ApplicationForm = context.get("form")
+        subjects_count = 0
+        lesson_type = ""
+        if form:
+            data = form.data if form.is_bound else form.initial
+            if data.get("subject1"):
+                subjects_count += 1
+            if data.get("subject2"):
+                subjects_count += 1
+            lesson_type = data.get("lesson_type", "")
+        context["application_price"] = get_application_price(
+            lesson_type, subjects_count
+        )
+        return context

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -6,5 +6,8 @@
     {% csrf_token %}
     {{ form.as_p }}
     <button type="submit">Записаться</button>
+    {% if application_price %}
+      <p class="application-price">{{ application_price }}</p>
+    {% endif %}
   </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- compute application price based on lesson type and selected subjects
- show calculated price on application form

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bd4313d0fc832d84d918725c95c6d1