### PR TITLE
Add pricing classes and markup

### DIFF
--- a/applications/utils.py
+++ b/applications/utils.py
@@ -1,28 +1,42 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Optional
 
 INDIVIDUAL_PRICE_PER_SUBJECT = 4000
 GROUP_PRICE_PER_SUBJECT = 2500
 
 
-def get_application_price(lesson_type: str, subjects_count: int) -> str:
-    """Return price string for application depending on lesson type and subjects count.
+def get_application_price(
+    lesson_type: str, subjects_count: int
+) -> Optional[Dict[str, str]]:
+    """Return price details for the application.
 
     The price is calculated as a simple multiplication of the number of
-    subjects by a predefined price per subject for each lesson type.
-    The result is formatted with a trailing ``"₽/мес"`` suffix.
+    subjects by a predefined price per subject for each lesson type. If either
+    ``subjects_count`` is non-positive or ``lesson_type`` is unknown, ``None``
+    is returned.
+
+    The dictionary contains the ``old`` price (20% higher), ``new`` price and
+    a short ``note`` explaining the discount. Each value is formatted with a
+    trailing ``"₽/мес"`` suffix.
     """
     if subjects_count <= 0:
-        return ""
+        return None
     price_per_subject: Dict[str, int] = {
         "individual": INDIVIDUAL_PRICE_PER_SUBJECT,
         "group": GROUP_PRICE_PER_SUBJECT,
     }
     per_subject = price_per_subject.get(lesson_type)
     if per_subject is None:
-        return ""
+        return None
     total = per_subject * subjects_count
-    # Format number with spaces as thousand separators
+    # Compute old price as 20% higher than current
+    old_total = int(total * 1.2)
+    # Format numbers with spaces as thousand separators
     total_str = f"{total:,}".replace(",", " ")
-    return f"{total_str} ₽/мес"
+    old_str = f"{old_total:,}".replace(",", " ")
+    return {
+        "old": f"{old_str} ₽/мес",
+        "new": f"{total_str} ₽/мес",
+        "note": "скидка 20%",
+    }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -152,3 +152,18 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .mb-8 { margin-bottom: 8px; }
 .mb-16 { margin-bottom: 16px; }
 .mt-12 { margin-top: 12px; }
+
+/* Price display */
+.price-old {
+  text-decoration: line-through;
+  color: #888;
+}
+
+.price-new {
+  font-weight: 700;
+}
+
+.price-note {
+  font-size: 0.9rem;
+  color: #555;
+}

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -7,7 +7,15 @@
     {{ form.as_p }}
     <button type="submit">Записаться</button>
     {% if application_price %}
-      <p class="application-price">{{ application_price }}</p>
+      <div class="application-price">
+        {% if application_price.old %}
+          <span class="price-old">{{ application_price.old }}</span>
+        {% endif %}
+        <span class="price-new">{{ application_price.new }}</span>
+        {% if application_price.note %}
+          <div class="price-note">{{ application_price.note }}</div>
+        {% endif %}
+      </div>
     {% endif %}
   </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `.price-old`, `.price-new`, and `.price-note` classes for price styling
- provide structured price details and update application form to display old and new prices with note

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb70981a4832db124c6a1f1165c52