### PR TITLE
Render application prices with placeholders and update note

### DIFF
--- a/applications/utils.py
+++ b/applications/utils.py
@@ -16,9 +16,9 @@ def get_application_price(
     ``subjects_count`` is non-positive or ``lesson_type`` is unknown, ``None``
     is returned.
 
-    The dictionary contains the ``old`` price (20% higher), ``new`` price and
-    a short ``note`` explaining the discount. Each value is formatted with a
-    trailing ``"₽/мес"`` suffix.
+    The dictionary contains the ``original`` price (20% higher), ``current``
+    price and a short ``note`` mentioning the validity date. Each value is
+    formatted with a trailing ``"₽/мес"`` suffix.
     """
     if subjects_count <= 0:
         return None
@@ -30,13 +30,13 @@ def get_application_price(
     if per_subject is None:
         return None
     total = per_subject * subjects_count
-    # Compute old price as 20% higher than current
-    old_total = int(total * 1.2)
+    # Compute original price as 20% higher than current
+    original_total = int(total * 1.2)
     # Format numbers with spaces as thousand separators
     total_str = f"{total:,}".replace(",", " ")
-    old_str = f"{old_total:,}".replace(",", " ")
+    original_str = f"{original_total:,}".replace(",", " ")
     return {
-        "old": f"{old_str} ₽/мес",
-        "new": f"{total_str} ₽/мес",
-        "note": "скидка 20%",
+        "original": f"{original_str} ₽/мес",
+        "current": f"{total_str} ₽/мес",
+        "note": "до 30 сентября",
     }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -52,15 +52,15 @@ function updatePrice() {
   if (!perSubject) return;
 
   const total = perSubject * subjectsCount;
-  const oldTotal = Math.round(total * 1.2);
+  const originalTotal = Math.round(total * 1.2);
   const format = (n) => n.toLocaleString('ru-RU').replace(/\u00A0/g, ' ');
 
   if (priceOldEl) {
-    priceOldEl.textContent = `${format(oldTotal)} ₽/мес`;
+    priceOldEl.textContent = `${format(originalTotal)} ₽/мес`;
   }
   priceNewEl.textContent = `${format(total)} ₽/мес`;
   if (priceNoteEl) {
-    priceNoteEl.textContent = 'скидка 20%';
+    priceNoteEl.textContent = 'до 30 сентября';
   }
 }
 

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -6,16 +6,10 @@
     {% csrf_token %}
     {{ form.as_p }}
     <button type="submit">Записаться</button>
-    {% if application_price %}
-      <div class="application-price">
-        {% if application_price.old %}
-          <span class="price-old">{{ application_price.old }}</span>
-        {% endif %}
-        <span class="price-new">{{ application_price.new }}</span>
-        {% if application_price.note %}
-          <div class="price-note">{{ application_price.note }}</div>
-        {% endif %}
-      </div>
-    {% endif %}
+    <p class="application-price">
+      <span class="price-old">{{ application_price.original|default:"" }}</span>
+      <span class="price-new">{{ application_price.current|default:"" }}</span>
+      <span class="price-note">до 30 сентября</span>
+    </p>
   </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Always render the application price block with spans for original, current and note
- Rename price fields to original/current and show "до 30 сентября" note
- Update pricing script to fill spans dynamically with new note text

## Testing
- `pytest` (fails: Requested setting INSTALLED_APPS, but settings are not configured)
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb950915c832da5f23fa25347544c