### PR TITLE
Add discountable application pricing defaults

### DIFF
--- a/applications/tests.py
+++ b/applications/tests.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
@@ -54,3 +56,19 @@ class ApplicationTests(TestCase):
         if cl:
             self.assertEqual(cl.queryset.count(), 1)
             self.assertEqual(cl.queryset.first().contact_name, "Processed")
+
+
+class ApplicationPriceTests(TestCase):
+    def test_default_price_in_context(self) -> None:
+        response = self.client.get(reverse("applications:apply"))
+        self.assertEqual(response.status_code, 200)
+        price = response.context.get("application_price")
+        expected_note = f"до 30.09.{date.today().year}"
+        self.assertEqual(
+            price,
+            {
+                "original": "3 000 ₽/мес",
+                "current": "2 500 ₽/мес",
+                "note": expected_note,
+            },
+        )

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date
 from typing import Dict, Optional
 
 INDIVIDUAL_PRICE_PER_SUBJECT = 4000
@@ -7,7 +8,11 @@ GROUP_PRICE_PER_SUBJECT = 2500
 
 
 def get_application_price(
-    lesson_type: str, subjects_count: int
+    lesson_type: str,
+    subjects_count: int,
+    *,
+    with_discount: bool = False,
+    promo_until: Optional[date] = None,
 ) -> Optional[Dict[str, str]]:
     """Return price details for the application.
 
@@ -16,9 +21,11 @@ def get_application_price(
     ``subjects_count`` is non-positive or ``lesson_type`` is unknown, ``None``
     is returned.
 
-    The dictionary contains the ``original`` price (20% higher), ``current``
+    When ``with_discount`` is ``True`` and ``promo_until`` is provided, the
+    returned dictionary contains the ``original`` price (20% higher), ``current``
     price and a short ``note`` mentioning the validity date. Each value is
-    formatted with a trailing ``"₽/мес"`` suffix.
+    formatted with a trailing ``"₽/мес"`` suffix. Otherwise only the ``current``
+    price is included.
     """
     if subjects_count <= 0:
         return None
@@ -30,13 +37,17 @@ def get_application_price(
     if per_subject is None:
         return None
     total = per_subject * subjects_count
-    # Compute original price as 20% higher than current
-    original_total = int(total * 1.2)
     # Format numbers with spaces as thousand separators
     total_str = f"{total:,}".replace(",", " ")
-    original_str = f"{original_total:,}".replace(",", " ")
-    return {
-        "original": f"{original_str} ₽/мес",
-        "current": f"{total_str} ₽/мес",
-        "note": "до 30 сентября",
-    }
+    result: Dict[str, str] = {"current": f"{total_str} ₽/мес"}
+    if with_discount and promo_until:
+        # Compute original price as 20% higher than current
+        original_total = int(total * 1.2)
+        original_str = f"{original_total:,}".replace(",", " ")
+        result.update(
+            {
+                "original": f"{original_str} ₽/мес",
+                "note": f"до {promo_until.strftime('%d.%m.%Y')}",
+            }
+        )
+    return result

--- a/applications/views.py
+++ b/applications/views.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict
+from datetime import date
 
 from django.urls import reverse_lazy
 from django.views.generic import FormView
@@ -44,7 +45,14 @@ class ApplicationCreateView(FormView):
             if data.get("subject2"):
                 subjects_count += 1
             lesson_type = data.get("lesson_type", "")
+        if subjects_count == 0:
+            subjects_count = 1
+        if not lesson_type:
+            lesson_type = "group"
         context["application_price"] = get_application_price(
-            lesson_type, subjects_count
+            lesson_type,
+            subjects_count,
+            with_discount=True,
+            promo_until=date(date.today().year, 9, 30),
         )
         return context


### PR DESCRIPTION
## Summary
- Ensure `ApplicationCreateView` defaults to one group subject
- Support discounts and promo deadline in `get_application_price`
- Add test for default application price

## Testing
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bdba7fb22c832d85d8ef20ce677976