### PR TITLE
feat: add discount-aware group pricing

### DIFF
--- a/applications/tests.py
+++ b/applications/tests.py
@@ -63,12 +63,12 @@ class ApplicationPriceTests(TestCase):
         response = self.client.get(reverse("applications:apply"))
         self.assertEqual(response.status_code, 200)
         price = response.context.get("application_price")
-        expected_note = f"до 30.09.{date.today().year}"
+        expected_date = date(date.today().year, 9, 30)
         self.assertEqual(
             price,
             {
-                "original": "3 000 ₽/мес",
-                "current": "2 500 ₽/мес",
-                "note": expected_note,
+                "original": 5000,
+                "current": 3000,
+                "promo_until": expected_date,
             },
         )

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Dict, Optional
+from typing import Optional, TypedDict
 
 INDIVIDUAL_PRICE_PER_SUBJECT = 4000
-GROUP_PRICE_PER_SUBJECT = 2500
+GROUP_ORIGINAL_PRICE_PER_SUBJECT = 5000
+GROUP_DISCOUNT_PRICE_PER_SUBJECT = 3000
+
+
+class ApplicationPrice(TypedDict):
+    current: int
+    original: int | None
+    promo_until: date | None
 
 
 def get_application_price(
@@ -12,42 +19,36 @@ def get_application_price(
     subjects_count: int,
     *,
     with_discount: bool = False,
-    promo_until: Optional[date] = None,
-) -> Optional[Dict[str, str]]:
-    """Return price details for the application.
+    promo_until: date | None = None,
+) -> ApplicationPrice | None:
+    """Calculate price details for the application.
 
-    The price is calculated as a simple multiplication of the number of
-    subjects by a predefined price per subject for each lesson type. If either
-    ``subjects_count`` is non-positive or ``lesson_type`` is unknown, ``None``
-    is returned.
-
-    When ``with_discount`` is ``True`` and ``promo_until`` is provided, the
-    returned dictionary contains the ``original`` price (20% higher), ``current``
-    price and a short ``note`` mentioning the validity date. Each value is
-    formatted with a trailing ``"₽/мес"`` suffix. Otherwise only the ``current``
-    price is included.
+    Returns ``None`` if ``lesson_type`` is unknown or ``subjects_count`` is not
+    positive. Otherwise returns a dictionary with ``current`` price, optional
+    ``original`` price and ``promo_until`` date when a discount applies.
     """
     if subjects_count <= 0:
         return None
-    price_per_subject: Dict[str, int] = {
-        "individual": INDIVIDUAL_PRICE_PER_SUBJECT,
-        "group": GROUP_PRICE_PER_SUBJECT,
-    }
-    per_subject = price_per_subject.get(lesson_type)
-    if per_subject is None:
+
+    if lesson_type == "individual":
+        current_per_subject = INDIVIDUAL_PRICE_PER_SUBJECT
+        original_per_subject: int | None = None
+    elif lesson_type == "group":
+        if with_discount:
+            current_per_subject = GROUP_DISCOUNT_PRICE_PER_SUBJECT
+            original_per_subject = GROUP_ORIGINAL_PRICE_PER_SUBJECT
+        else:
+            current_per_subject = GROUP_ORIGINAL_PRICE_PER_SUBJECT
+            original_per_subject = None
+    else:
         return None
-    total = per_subject * subjects_count
-    # Format numbers with spaces as thousand separators
-    total_str = f"{total:,}".replace(",", " ")
-    result: Dict[str, str] = {"current": f"{total_str} ₽/мес"}
-    if with_discount and promo_until:
-        # Compute original price as 20% higher than current
-        original_total = int(total * 1.2)
-        original_str = f"{original_total:,}".replace(",", " ")
-        result.update(
-            {
-                "original": f"{original_str} ₽/мес",
-                "note": f"до {promo_until.strftime('%d.%m.%Y')}",
-            }
-        )
-    return result
+
+    current_total = current_per_subject * subjects_count
+    original_total = (
+        original_per_subject * subjects_count if original_per_subject else None
+    )
+    return {
+        "current": current_total,
+        "original": original_total,
+        "promo_until": promo_until if original_total is not None else None,
+    }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -27,7 +27,8 @@ function setMode(mode) {
 }
 
 const INDIVIDUAL_PRICE_PER_SUBJECT = 4000;
-const GROUP_PRICE_PER_SUBJECT = 2500;
+const GROUP_ORIGINAL_PRICE_PER_SUBJECT = 5000;
+const GROUP_DISCOUNT_PRICE_PER_SUBJECT = 3000;
 
 function updatePrice() {
   const lessonTypeEl = document.getElementById('id_lesson_type');
@@ -44,23 +45,29 @@ function updatePrice() {
   if (subject2El.value) subjectsCount += 1;
   if (subjectsCount === 0) subjectsCount = 1;
 
-  const priceMap = {
-    individual: INDIVIDUAL_PRICE_PER_SUBJECT,
-    group: GROUP_PRICE_PER_SUBJECT,
-  };
-  const perSubject = priceMap[lessonType];
-  if (!perSubject) return;
+  let currentPerSubject;
+  let originalPerSubject = null;
+  if (lessonType === 'group') {
+    currentPerSubject = GROUP_DISCOUNT_PRICE_PER_SUBJECT;
+    originalPerSubject = GROUP_ORIGINAL_PRICE_PER_SUBJECT;
+  } else {
+    currentPerSubject = INDIVIDUAL_PRICE_PER_SUBJECT;
+  }
 
-  const total = perSubject * subjectsCount;
-  const originalTotal = Math.round(total * 1.2);
+  const currentTotal = currentPerSubject * subjectsCount;
   const format = (n) => n.toLocaleString('ru-RU').replace(/\u00A0/g, ' ');
 
+  priceNewEl.textContent = `${format(currentTotal)} ₽/мес`;
   if (priceOldEl) {
-    priceOldEl.textContent = `${format(originalTotal)} ₽/мес`;
+    if (originalPerSubject) {
+      const originalTotal = originalPerSubject * subjectsCount;
+      priceOldEl.textContent = `${format(originalTotal)} ₽/мес`;
+    } else {
+      priceOldEl.textContent = '';
+    }
   }
-  priceNewEl.textContent = `${format(total)} ₽/мес`;
   if (priceNoteEl) {
-    priceNoteEl.textContent = 'до 30 сентября';
+    priceNoteEl.textContent = originalPerSubject ? 'до 30 сентября' : '';
   }
 }
 

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -7,9 +7,15 @@
     {{ form.as_p }}
     <button type="submit">Записаться</button>
     <p class="application-price">
-      <span class="price-old">{{ application_price.original|default:"" }}</span>
-      <span class="price-new">{{ application_price.current|default:"" }}</span>
-      <span class="price-note">до 30 сентября</span>
+      <span class="price-old">
+        {% if application_price.original %}{{ application_price.original }} ₽/мес{% endif %}
+      </span>
+      <span class="price-new">
+        {% if application_price.current %}{{ application_price.current }} ₽/мес{% endif %}
+      </span>
+      <span class="price-note">
+        {% if application_price.promo_until %}до {{ application_price.promo_until|date:"d.m.Y" }}{% endif %}
+      </span>
     </p>
   </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- expand application price calculation to handle discount and promo periods
- show original and discounted group prices with promo info

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbbb09afc832d9a90ef290092752f