### PR TITLE
Display dynamic application price on about page

### DIFF
--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -62,7 +62,11 @@
             {{ form.lesson_type.errors }}
           </div>
         </div>
-        <div class="muted">{% trans "Цена: ..." %}</div>
+        <p class="application-price">
+          <span class="price-old">{% if application_price.original %}{{ application_price.original }} ₽/мес{% endif %}</span>
+          <span class="price-new">{% if application_price.current %}{{ application_price.current }} ₽/мес{% endif %}</span>
+          <span class="price-note">{% if application_price.promo_until %}до {{ application_price.promo_until|date:"d.m.Y" }}{% endif %}</span>
+        </p>
         <button type="submit" class="btn accent">{% trans "Записаться" %}</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- show dynamic application pricing in about page

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbe02c790832db05be357f70df0c3