### PR TITLE
Add initial application price calculation for home view

### DIFF
--- a/fractalschool/views.py
+++ b/fractalschool/views.py
@@ -1,6 +1,7 @@
 from django.views.generic import TemplateView
 
 from applications.forms import ApplicationForm
+from applications.utils import date, get_application_price
 
 
 class HomeView(TemplateView):
@@ -10,5 +11,8 @@ class HomeView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["form"] = ApplicationForm()
+        context["application_price"] = get_application_price(
+            "group", 1, with_discount=True, promo_until=date(date.today().year, 9, 30)
+        )
         return context
 


### PR DESCRIPTION
## Summary
- Compute discounted group application price in home view context
- Display initial application price in about section consumed by `updatePrice()` JS

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bdcc0653dc832db6f886c81bc7b372