### PR TITLE
Highlight testimonials block on home page

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -72,7 +72,7 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .pill:hover { border-color: color-mix(in srgb, var(--accent) 60%, var(--border)); }
 
 /* Testimonials */
-.reviews-block { background: var(--card); }
+.reviews-block {}
 .testimonials { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px,1fr)); gap: 12px; }
 .quote { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 16px; color: var(--muted); }
 .quote strong { color: var(--text); }

--- a/templates/partials/testimonials.html
+++ b/templates/partials/testimonials.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <section class="section">
   <div class="container">
-    <div class="block reviews-block">
+    <div class="block block--futuristic reviews-block">
         <h3 class="section-title">{% trans "Отзывы" %}</h3>
       <div class="testimonials">
           <div class="quote">{% blocktrans trimmed %}«Виктор, спасибо Вам огромное!!! Я вообще в шоке!!! Я Вам бесконечно благодарен!!!».<br><strong>— Дмитрий, 100 баллов на ЕГЭ по информатике</strong>{% endblocktrans %}</div>


### PR DESCRIPTION
## Summary
- Add futuristic highlight to testimonials block on home page
- Remove background override to allow unified block styling

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bde34db3dc832da6c524690981cb46