### PR TITLE
Implement fixed pricing variants and update selection logic

### DIFF
--- a/applications/tests.py
+++ b/applications/tests.py
@@ -64,33 +64,40 @@ class ApplicationPriceTests(TestCase):
         response = self.client.get(reverse("applications:apply"))
         self.assertEqual(response.status_code, 200)
         price = response.context.get("application_price")
-        self.assertIsNone(price)
-
-    def test_get_price_individual_two_subjects_variant2(self) -> None:
         expected_date = date(date.today().year, 9, 30)
-        price = get_application_price(
-            "individual", 2, with_discount=True, promo_until=expected_date
-        )
-        self.assertEqual(
-            price,
-            {
-                "original": 10000,
-                "current": 5000,
-                "promo_until": expected_date,
-            },
-        )
-
-    def test_get_price_group_one_subject_variant2(self) -> None:
-        expected_date = date(date.today().year, 9, 30)
-        price = get_application_price(
-            "group", 1, with_discount=True, promo_until=expected_date
-        )
         self.assertEqual(
             price,
             {
                 "original": 5000,
                 "current": 3000,
                 "promo_until": expected_date,
+                "unit": "₽/мес",
+            },
+        )
+
+    def test_get_price_individual_two_subjects_variant2(self) -> None:
+        expected_date = date(date.today().year, 9, 30)
+        price = get_application_price("individual", 2, promo_until=expected_date)
+        self.assertEqual(
+            price,
+            {
+                "original": 10000,
+                "current": 5000,
+                "promo_until": expected_date,
+                "unit": "₽/мес",
+            },
+        )
+
+    def test_get_price_group_one_subject_variant2(self) -> None:
+        expected_date = date(date.today().year, 9, 30)
+        price = get_application_price("group", 1, promo_until=expected_date)
+        self.assertEqual(
+            price,
+            {
+                "original": 10000,
+                "current": 5000,
+                "promo_until": expected_date,
+                "unit": "₽/мес",
             },
         )
 
@@ -102,6 +109,20 @@ class ApplicationPriceTests(TestCase):
                 "original": None,
                 "current": 2000,
                 "promo_until": None,
+                "unit": "₽ за занятие (60 минут)",
+            },
+        )
+
+    def test_get_price_no_subjects_variant1(self) -> None:
+        expected_date = date(date.today().year, 9, 30)
+        price = get_application_price("group", 0, promo_until=expected_date)
+        self.assertEqual(
+            price,
+            {
+                "original": 5000,
+                "current": 3000,
+                "promo_until": expected_date,
+                "unit": "₽/мес",
             },
         )
 
@@ -137,8 +158,8 @@ class ApplicationPriceTests(TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         return json.loads(result.stdout)
 
-    def test_js_group_one_subject_variant2(self) -> None:
-        data = self._run_js("group", 1)
+    def test_js_no_subjects_variant1(self) -> None:
+        data = self._run_js("group", 0)
         self.assertEqual(
             data,
             {
@@ -148,11 +169,22 @@ class ApplicationPriceTests(TestCase):
             },
         )
 
+    def test_js_group_one_subject_variant2(self) -> None:
+        data = self._run_js("group", 1)
+        self.assertEqual(
+            data,
+            {
+                "old": "10 000 ₽/мес",
+                "current": "5 000 ₽/мес",
+                "note": "до 30 сентября",
+            },
+        )
+
     def test_js_group_two_subjects_variant3(self) -> None:
         data = self._run_js("group", 2)
         self.assertEqual(
             data,
-            {"old": "", "current": "2 000 ₽ за занятие", "note": ""},
+            {"old": "", "current": "2 000 ₽ за занятие (60 минут)", "note": ""},
         )
 
     def test_js_individual_two_subjects_variant2(self) -> None:

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -3,65 +3,57 @@ from __future__ import annotations
 from datetime import date
 from typing import TypedDict
 
-INDIVIDUAL_PRICE_PER_SUBJECT = 4000
-INDIVIDUAL_ORIGINAL_PRICE_PER_SUBJECT = 5000
-INDIVIDUAL_DISCOUNT_PRICE_PER_SUBJECT = 2500
-GROUP_ORIGINAL_PRICE_PER_SUBJECT = 5000
-GROUP_DISCOUNT_PRICE_PER_SUBJECT = 3000
-GROUP_TWO_SUBJECTS_PRICE = 2000
+# Pricing variants
+VARIANT1_CURRENT = 3000
+VARIANT1_ORIGINAL = 5000
+VARIANT2_CURRENT = 5000
+VARIANT2_ORIGINAL = 10000
+VARIANT3_PRICE = 2000
+
+VARIANT3_UNIT = "₽ за занятие (60 минут)"
+DEFAULT_UNIT = "₽/мес"
 
 
 class ApplicationPrice(TypedDict):
     current: int
     original: int | None
     promo_until: date | None
+    unit: str
 
 
 def get_application_price(
     lesson_type: str,
     subjects_count: int,
     *,
-    with_discount: bool = False,
     promo_until: date | None = None,
 ) -> ApplicationPrice | None:
-    """Calculate price details for the application.
+    """Return application price based on lesson type and subjects count."""
 
-    Returns ``None`` if ``lesson_type`` is unknown or ``subjects_count`` is not
-    positive. Otherwise returns a dictionary with ``current`` price, optional
-    ``original`` price and ``promo_until`` date when a discount applies.
-    """
-    if subjects_count <= 0:
+    if subjects_count < 0:
         return None
 
-    if lesson_type == "individual":
-        if with_discount and subjects_count == 2:
-            current_total = INDIVIDUAL_DISCOUNT_PRICE_PER_SUBJECT * subjects_count
-            original_total: int | None = (
-                INDIVIDUAL_ORIGINAL_PRICE_PER_SUBJECT * subjects_count
-            )
-            promo = promo_until
-        else:
-            current_total = INDIVIDUAL_PRICE_PER_SUBJECT * subjects_count
-            original_total = None
-            promo = None
-    elif lesson_type == "group":
-        if subjects_count == 2:
-            current_total = GROUP_TWO_SUBJECTS_PRICE
-            original_total = None
-            promo = None
-        elif with_discount:
-            current_total = GROUP_DISCOUNT_PRICE_PER_SUBJECT * subjects_count
-            original_total = GROUP_ORIGINAL_PRICE_PER_SUBJECT * subjects_count
-            promo = promo_until
-        else:
-            current_total = GROUP_ORIGINAL_PRICE_PER_SUBJECT * subjects_count
-            original_total = None
-            promo = None
-    else:
+    if subjects_count == 0:
+        return {
+            "current": VARIANT1_CURRENT,
+            "original": VARIANT1_ORIGINAL,
+            "promo_until": promo_until,
+            "unit": DEFAULT_UNIT,
+        }
+
+    if lesson_type not in {"individual", "group"}:
         return None
+
+    if lesson_type == "group" and subjects_count == 2:
+        return {
+            "current": VARIANT3_PRICE,
+            "original": None,
+            "promo_until": None,
+            "unit": VARIANT3_UNIT,
+        }
 
     return {
-        "current": current_total,
-        "original": original_total,
-        "promo_until": promo,
+        "current": VARIANT2_CURRENT,
+        "original": VARIANT2_ORIGINAL,
+        "promo_until": promo_until,
+        "unit": DEFAULT_UNIT,
     }

--- a/applications/views.py
+++ b/applications/views.py
@@ -50,7 +50,6 @@ class ApplicationCreateView(FormView):
         context["application_price"] = get_application_price(
             lesson_type,
             subjects_count,
-            with_discount=True,
             promo_until=date(date.today().year, 9, 30),
         )
         return context

--- a/fractalschool/views.py
+++ b/fractalschool/views.py
@@ -12,7 +12,7 @@ class HomeView(TemplateView):
         context = super().get_context_data(**kwargs)
         context["form"] = ApplicationForm()
         context["application_price"] = get_application_price(
-            "group", 1, with_discount=True, promo_until=date(date.today().year, 9, 30)
+            "group", 1, promo_until=date(date.today().year, 9, 30)
         )
         return context
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -24,14 +24,16 @@ function setMode(mode) {
   }
 
   input.value = mode;
+  updatePrice();
 }
 
-const INDIVIDUAL_PRICE_PER_SUBJECT = 4000;
-const INDIVIDUAL_ORIGINAL_PRICE_PER_SUBJECT = 5000;
-const INDIVIDUAL_DISCOUNT_PRICE_PER_SUBJECT = 2500;
-const GROUP_ORIGINAL_PRICE_PER_SUBJECT = 5000;
-const GROUP_DISCOUNT_PRICE_PER_SUBJECT = 3000;
-const GROUP_TWO_SUBJECTS_PRICE = 2000;
+const VARIANT1_CURRENT = 3000;
+const VARIANT1_ORIGINAL = 5000;
+const VARIANT2_CURRENT = 5000;
+const VARIANT2_ORIGINAL = 10000;
+const VARIANT3_PRICE = 2000;
+const VARIANT3_UNIT = '₽ за занятие (60 минут)';
+const DEFAULT_UNIT = '₽/мес';
 
 function updatePrice() {
   const lessonTypeEl = document.getElementById('id_lesson_type');
@@ -42,38 +44,25 @@ function updatePrice() {
   const priceNoteEl = document.querySelector('.price-note');
   if (!lessonTypeEl || !subject1El || !subject2El || !priceNewEl) return;
 
-  const lessonType = lessonTypeEl.value;
+  const lessonType = lessonTypeEl.value || 'group';
   let subjectsCount = 0;
   if (subject1El.value) subjectsCount += 1;
   if (subject2El.value) subjectsCount += 1;
 
-  if (!lessonType || subjectsCount === 0) {
-    priceNewEl.textContent = '';
-    if (priceOldEl) priceOldEl.textContent = '';
-    if (priceNoteEl) priceNoteEl.textContent = '';
-    return;
-  }
-
   const format = (n) => n.toLocaleString('ru-RU').replace(/\u00A0/g, ' ');
   let currentTotal;
   let originalTotal = null;
-  let unit = '₽/мес';
+  let unit = DEFAULT_UNIT;
 
-  if (lessonType === 'individual') {
-    if (subjectsCount === 2) {
-      currentTotal = INDIVIDUAL_DISCOUNT_PRICE_PER_SUBJECT * subjectsCount;
-      originalTotal = INDIVIDUAL_ORIGINAL_PRICE_PER_SUBJECT * subjectsCount;
-    } else {
-      currentTotal = INDIVIDUAL_PRICE_PER_SUBJECT * subjectsCount;
-    }
-  } else if (lessonType === 'group') {
-    if (subjectsCount === 2) {
-      currentTotal = GROUP_TWO_SUBJECTS_PRICE;
-      unit = '₽ за занятие';
-    } else {
-      currentTotal = GROUP_DISCOUNT_PRICE_PER_SUBJECT * subjectsCount;
-      originalTotal = GROUP_ORIGINAL_PRICE_PER_SUBJECT * subjectsCount;
-    }
+  if (subjectsCount === 0) {
+    currentTotal = VARIANT1_CURRENT;
+    originalTotal = VARIANT1_ORIGINAL;
+  } else if (lessonType === 'group' && subjectsCount === 2) {
+    currentTotal = VARIANT3_PRICE;
+    unit = VARIANT3_UNIT;
+  } else {
+    currentTotal = VARIANT2_CURRENT;
+    originalTotal = VARIANT2_ORIGINAL;
   }
 
   priceNewEl.textContent = `${format(currentTotal)} ${unit}`;
@@ -87,7 +76,6 @@ function updatePrice() {
 
 document.addEventListener('DOMContentLoaded', () => {
   setMode('group');
-  updatePrice();
   ['id_grade', 'id_subject1', 'id_subject2', 'id_lesson_type'].forEach((id) => {
     const el = document.getElementById(id);
     if (el) {

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -11,7 +11,7 @@
         {% if application_price.original %}{{ application_price.original }} ₽/мес{% endif %}
       </span>
       <span class="price-new">
-        {% if application_price.current %}{{ application_price.current }} ₽/мес{% endif %}
+        {% if application_price.current %}{{ application_price.current }} {{ application_price.unit|default:"₽/мес" }}{% endif %}
       </span>
       <span class="price-note">
         {% if application_price.promo_until %}до {{ application_price.promo_until|date:"d.m.Y" }}{% endif %}

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -64,7 +64,7 @@
         </div>
         <p class="application-price">
           <span class="price-old">{% if application_price.original %}{{ application_price.original }} ₽/мес{% endif %}</span>
-          <span class="price-new">{% if application_price.current %}{{ application_price.current }} ₽/мес{% endif %}</span>
+          <span class="price-new">{% if application_price.current %}{{ application_price.current }} {{ application_price.unit|default:"₽/мес" }}{% endif %}</span>
           <span class="price-note">{% if application_price.promo_until %}до {{ application_price.promo_until|date:"d.m.Y" }}{% endif %}</span>
         </p>
         <button type="submit" class="btn accent">{% trans "Записаться" %}</button>


### PR DESCRIPTION
## Summary
- replace subject-based pricing with three fixed variants
- update frontend to show 2000 ₽ per lesson for two group subjects and recalc on mode switch
- adjust templates, views, and tests for new pricing data structure

## Testing
- `python -m pytest -q` *(fails: django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*
- `python manage.py test applications.tests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68bdec4e77dc832d8dd20c5d64cad55d