### PR TITLE
Handle per-lesson pricing and hide empty price elements

### DIFF
--- a/applications/tests.py
+++ b/applications/tests.py
@@ -71,7 +71,7 @@ class ApplicationPriceTests(TestCase):
                 "original": 5000,
                 "current": 3000,
                 "promo_until": expected_date,
-                "unit": "₽/мес",
+                "per_lesson": False,
             },
         )
 
@@ -84,7 +84,7 @@ class ApplicationPriceTests(TestCase):
                 "original": 10000,
                 "current": 5000,
                 "promo_until": expected_date,
-                "unit": "₽/мес",
+                "per_lesson": False,
             },
         )
 
@@ -97,7 +97,7 @@ class ApplicationPriceTests(TestCase):
                 "original": 10000,
                 "current": 5000,
                 "promo_until": expected_date,
-                "unit": "₽/мес",
+                "per_lesson": False,
             },
         )
 
@@ -109,7 +109,7 @@ class ApplicationPriceTests(TestCase):
                 "original": None,
                 "current": 2000,
                 "promo_until": None,
-                "unit": "₽ за занятие (60 минут)",
+                "per_lesson": True,
             },
         )
 
@@ -122,7 +122,7 @@ class ApplicationPriceTests(TestCase):
                 "original": 5000,
                 "current": 3000,
                 "promo_until": expected_date,
-                "unit": "₽/мес",
+                "per_lesson": False,
             },
         )
 
@@ -140,9 +140,9 @@ class ApplicationPriceTests(TestCase):
           id_subject1: {{ value: {json.dumps(subject1)}, addEventListener: () => {{}} }},
           id_subject2: {{ value: {json.dumps(subject2)}, addEventListener: () => {{}} }},
         }};
-        const priceOld = {{ textContent: '' }};
-        const priceNew = {{ textContent: '' }};
-        const priceNote = {{ textContent: '' }};
+        const priceOld = {{ textContent: '', style: {{ display: '' }} }};
+        const priceNew = {{ textContent: '', style: {{ display: '' }} }};
+        const priceNote = {{ textContent: '', style: {{ display: '' }} }};
         global.document = {{
           getElementById: (id) => inputs[id],
           querySelector: (sel) => sel === '.price-old' ? priceOld : sel === '.price-new' ? priceNew : priceNote,
@@ -150,7 +150,13 @@ class ApplicationPriceTests(TestCase):
         }};
         const {{ updatePrice }} = require('./static/js/main.js');
         updatePrice();
-        console.log(JSON.stringify({{old: priceOld.textContent, current: priceNew.textContent, note: priceNote.textContent}}));
+        console.log(JSON.stringify({{
+          old: priceOld.textContent,
+          current: priceNew.textContent,
+          note: priceNote.textContent,
+          oldDisplay: priceOld.style.display,
+          noteDisplay: priceNote.style.display,
+        }}));
         """
         result = subprocess.run(
             ["node", "-e", script], cwd=Path(__file__).resolve().parents[1], capture_output=True, text=True
@@ -166,6 +172,8 @@ class ApplicationPriceTests(TestCase):
                 "old": "5 000 ₽/мес",
                 "current": "3 000 ₽/мес",
                 "note": "до 30 сентября",
+                "oldDisplay": "",
+                "noteDisplay": "",
             },
         )
 
@@ -177,6 +185,8 @@ class ApplicationPriceTests(TestCase):
                 "old": "10 000 ₽/мес",
                 "current": "5 000 ₽/мес",
                 "note": "до 30 сентября",
+                "oldDisplay": "",
+                "noteDisplay": "",
             },
         )
 
@@ -184,7 +194,13 @@ class ApplicationPriceTests(TestCase):
         data = self._run_js("group", 2)
         self.assertEqual(
             data,
-            {"old": "", "current": "2 000 ₽ за занятие (60 минут)", "note": ""},
+            {
+                "old": "",
+                "current": "2 000 ₽ за занятие (60 минут)",
+                "note": "",
+                "oldDisplay": "none",
+                "noteDisplay": "none",
+            },
         )
 
     def test_js_individual_two_subjects_variant2(self) -> None:
@@ -195,5 +211,7 @@ class ApplicationPriceTests(TestCase):
                 "old": "10 000 ₽/мес",
                 "current": "5 000 ₽/мес",
                 "note": "до 30 сентября",
+                "oldDisplay": "",
+                "noteDisplay": "",
             },
         )

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -10,15 +10,11 @@ VARIANT2_CURRENT = 5000
 VARIANT2_ORIGINAL = 10000
 VARIANT3_PRICE = 2000
 
-VARIANT3_UNIT = "₽ за занятие (60 минут)"
-DEFAULT_UNIT = "₽/мес"
-
-
 class ApplicationPrice(TypedDict):
     current: int
     original: int | None
     promo_until: date | None
-    unit: str
+    per_lesson: bool
 
 
 def get_application_price(
@@ -37,7 +33,7 @@ def get_application_price(
             "current": VARIANT1_CURRENT,
             "original": VARIANT1_ORIGINAL,
             "promo_until": promo_until,
-            "unit": DEFAULT_UNIT,
+            "per_lesson": False,
         }
 
     if lesson_type not in {"individual", "group"}:
@@ -48,12 +44,12 @@ def get_application_price(
             "current": VARIANT3_PRICE,
             "original": None,
             "promo_until": None,
-            "unit": VARIANT3_UNIT,
+            "per_lesson": True,
         }
 
     return {
         "current": VARIANT2_CURRENT,
         "original": VARIANT2_ORIGINAL,
         "promo_until": promo_until,
-        "unit": DEFAULT_UNIT,
+        "per_lesson": False,
     }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -52,25 +52,38 @@ function updatePrice() {
   const format = (n) => n.toLocaleString('ru-RU').replace(/\u00A0/g, ' ');
   let currentTotal;
   let originalTotal = null;
-  let unit = DEFAULT_UNIT;
+  let perLesson = false;
 
   if (subjectsCount === 0) {
     currentTotal = VARIANT1_CURRENT;
     originalTotal = VARIANT1_ORIGINAL;
   } else if (lessonType === 'group' && subjectsCount === 2) {
     currentTotal = VARIANT3_PRICE;
-    unit = VARIANT3_UNIT;
+    perLesson = true;
   } else {
     currentTotal = VARIANT2_CURRENT;
     originalTotal = VARIANT2_ORIGINAL;
   }
 
+  const unit = perLesson ? VARIANT3_UNIT : DEFAULT_UNIT;
   priceNewEl.textContent = `${format(currentTotal)} ${unit}`;
   if (priceOldEl) {
-    priceOldEl.textContent = originalTotal ? `${format(originalTotal)} ₽/мес` : '';
+    if (originalTotal) {
+      priceOldEl.textContent = `${format(originalTotal)} ₽/мес`;
+      priceOldEl.style.display = '';
+    } else {
+      priceOldEl.textContent = '';
+      priceOldEl.style.display = 'none';
+    }
   }
   if (priceNoteEl) {
-    priceNoteEl.textContent = originalTotal ? 'до 30 сентября' : '';
+    if (originalTotal) {
+      priceNoteEl.textContent = 'до 30 сентября';
+      priceNoteEl.style.display = '';
+    } else {
+      priceNoteEl.textContent = '';
+      priceNoteEl.style.display = 'none';
+    }
   }
 }
 

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -7,15 +7,18 @@
     {{ form.as_p }}
     <button type="submit">Записаться</button>
     <p class="application-price">
-      <span class="price-old">
-        {% if application_price.original %}{{ application_price.original }} ₽/мес{% endif %}
-      </span>
-      <span class="price-new">
-        {% if application_price.current %}{{ application_price.current }} {{ application_price.unit|default:"₽/мес" }}{% endif %}
-      </span>
-      <span class="price-note">
-        {% if application_price.promo_until %}до {{ application_price.promo_until|date:"d.m.Y" }}{% endif %}
-      </span>
+      {% if application_price.original %}
+        <span class="price-old">{{ application_price.original }} ₽/мес</span>
+      {% endif %}
+      {% if application_price.current %}
+        <span class="price-new">
+          {{ application_price.current }}
+          {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+        </span>
+      {% endif %}
+      {% if application_price.promo_until %}
+        <span class="price-note">до {{ application_price.promo_until|date:"d.m.Y" }}</span>
+      {% endif %}
     </p>
   </form>
 {% endblock %}

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -63,9 +63,18 @@
           </div>
         </div>
         <p class="application-price">
-          <span class="price-old">{% if application_price.original %}{{ application_price.original }} ₽/мес{% endif %}</span>
-          <span class="price-new">{% if application_price.current %}{{ application_price.current }} {{ application_price.unit|default:"₽/мес" }}{% endif %}</span>
-          <span class="price-note">{% if application_price.promo_until %}до {{ application_price.promo_until|date:"d.m.Y" }}{% endif %}</span>
+          {% if application_price.original %}
+            <span class="price-old">{{ application_price.original }} ₽/мес</span>
+          {% endif %}
+          {% if application_price.current %}
+            <span class="price-new">
+              {{ application_price.current }}
+              {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+            </span>
+          {% endif %}
+          {% if application_price.promo_until %}
+            <span class="price-note">до {{ application_price.promo_until|date:"d.m.Y" }}</span>
+          {% endif %}
         </p>
         <button type="submit" class="btn accent">{% trans "Записаться" %}</button>
       </form>


### PR DESCRIPTION
## Summary
- add `per_lesson` flag to pricing utility
- conditionally render original and promo date in application templates
- update JS price updater to hide empty price elements and switch units

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bdf151b074832d863536b5454f0920