### PR TITLE
Use actual subject count for pricing

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -36,17 +36,14 @@ class ApplicationCreateView(FormView):
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:  # type: ignore[override]
         context = super().get_context_data(**kwargs)
         form: ApplicationForm = context.get("form")
+        lesson_type = "group"
         subjects_count = 0
-        lesson_type = ""
         if form:
             data = form.data if form.is_bound else form.initial
-            if data.get("subject1"):
-                subjects_count += 1
-            if data.get("subject2"):
-                subjects_count += 1
-            lesson_type = data.get("lesson_type", "")
-        if not lesson_type:
-            lesson_type = "group"
+            subjects_count = sum(
+                1 for field in ("subject1", "subject2") if data.get(field)
+            )
+            lesson_type = data.get("lesson_type") or lesson_type
         context["application_price"] = get_application_price(
             lesson_type,
             subjects_count,

--- a/fractalschool/views.py
+++ b/fractalschool/views.py
@@ -12,7 +12,7 @@ class HomeView(TemplateView):
         context = super().get_context_data(**kwargs)
         context["form"] = ApplicationForm()
         context["application_price"] = get_application_price(
-            "group", 1, promo_until=date(date.today().year, 9, 30)
+            "group", 0, promo_until=date(date.today().year, 9, 30)
         )
         return context
 


### PR DESCRIPTION
## Summary
- compute subject count directly in ApplicationCreateView and call `get_application_price` with the real number (can be zero)
- show variant 1 pricing on the landing page when no subject is selected

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68bdf29c8464832dbc6ee938cf1512d7