### PR TITLE
Handle per-lesson unit for original price

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -69,7 +69,7 @@ function updatePrice() {
   priceNewEl.textContent = `${format(currentTotal)} ${unit}`;
   if (priceOldEl) {
     if (originalTotal) {
-      priceOldEl.textContent = `${format(originalTotal)} ₽/мес`;
+      priceOldEl.textContent = `${format(originalTotal)} ${unit}`;
       priceOldEl.style.display = '';
     } else {
       priceOldEl.textContent = '';

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -8,7 +8,10 @@
     <button type="submit">Записаться</button>
     <p class="application-price">
       {% if application_price.original %}
-        <span class="price-old">{{ application_price.original }} ₽/мес</span>
+        <span class="price-old">
+          {{ application_price.original }}
+          {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+        </span>
       {% endif %}
       {% if application_price.current %}
         <span class="price-new">

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -64,7 +64,10 @@
         </div>
         <p class="application-price">
           {% if application_price.original %}
-            <span class="price-old">{{ application_price.original }} ₽/мес</span>
+            <span class="price-old">
+              {{ application_price.original }}
+              {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+            </span>
           {% endif %}
           {% if application_price.current %}
             <span class="price-new">


### PR DESCRIPTION
## Summary
- Show unit for original prices in both templates using per-lesson wording when applicable
- Use shared unit logic in client-side price updater

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68be84dc700c832da43247819ff7f019