### PR TITLE
Use actual subject count for default pricing

### DIFF
--- a/fractalschool/views.py
+++ b/fractalschool/views.py
@@ -12,7 +12,7 @@ class HomeView(TemplateView):
         context = super().get_context_data(**kwargs)
         context["form"] = ApplicationForm()
         context["application_price"] = get_application_price(
-            "group", 1, promo_until=date(date.today().year, 9, 30)
+            "group", 0, promo_until=date(date.today().year, 9, 30)
         )
         return context
 


### PR DESCRIPTION
## Summary
- Display base variant pricing on landing by calling `get_application_price` with zero subjects

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68be860315cc832db70ff9919142c476