### PR TITLE
Handle individual lesson price first

### DIFF
--- a/applications/tests.py
+++ b/applications/tests.py
@@ -80,6 +80,19 @@ class ApplicationPriceTests(TestCase):
             },
         )
 
+    def test_get_price_individual_no_subjects_variant2(self) -> None:
+        expected_date = date(date.today().year, 9, 30)
+        price = get_application_price("individual", 0)
+        self.assertEqual(
+            price,
+            {
+                "original": 10000,
+                "current": 5000,
+                "promo_until": expected_date,
+                "per_lesson": False,
+            },
+        )
+
     def test_get_price_group_one_subject_variant2(self) -> None:
         expected_date = date(date.today().year, 9, 30)
         price = get_application_price("group", 1)
@@ -197,6 +210,19 @@ class ApplicationPriceTests(TestCase):
 
     def test_js_individual_two_subjects_variant2(self) -> None:
         data = self._run_js("individual", 2)
+        self.assertEqual(
+            data,
+            {
+                "old": "10 000 ₽/мес",
+                "current": "5 000 ₽/мес",
+                "note": "до 30 сентября",
+                "oldDisplay": "",
+                "noteDisplay": "",
+            },
+        )
+
+    def test_js_individual_no_subjects_variant2(self) -> None:
+        data = self._run_js("individual", 0)
         self.assertEqual(
             data,
             {

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -28,6 +28,14 @@ def get_application_price(
 
     promo_until = date(date.today().year, 9, 30)
 
+    if lesson_type == "individual":
+        return {
+            "current": VARIANT2_CURRENT,
+            "original": VARIANT2_ORIGINAL,
+            "promo_until": promo_until,
+            "per_lesson": False,
+        }
+
     if subjects_count == 0:
         return {
             "current": VARIANT1_CURRENT,

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -54,7 +54,10 @@ function updatePrice() {
   let originalTotal = null;
   let perLesson = false;
 
-  if (subjectsCount === 0) {
+  if (lessonType === 'individual') {
+    currentTotal = VARIANT2_CURRENT;
+    originalTotal = VARIANT2_ORIGINAL;
+  } else if (subjectsCount === 0) {
     currentTotal = VARIANT1_CURRENT;
     originalTotal = VARIANT1_ORIGINAL;
   } else if (lessonType === 'group' && subjectsCount === 2) {


### PR DESCRIPTION
## Summary
- Prioritize individual lesson pricing in backend `get_application_price`
- Mirror logic in frontend `updatePrice` for individual lessons
- Add tests for individual pricing with no subjects, including JS coverage

## Testing
- `python manage.py test applications`


------
https://chatgpt.com/codex/tasks/task_e_68be8d0a3cdc832daac4d508bdb6a8f0