### PR TITLE
feat: add individual per-lesson pricing and always return promo info

### DIFF
--- a/applications/tests.py
+++ b/applications/tests.py
@@ -67,29 +67,29 @@ class ApplicationPriceTests(TestCase):
         expected_price = get_application_price("group", 0)
         self.assertEqual(price, expected_price)
 
-    def test_get_price_individual_two_subjects_variant2(self) -> None:
+    def test_get_price_individual_two_subjects(self) -> None:
         expected_date = date(date.today().year, 9, 30)
         price = get_application_price("individual", 2)
         self.assertEqual(
             price,
             {
-                "original": 10000,
-                "current": 5000,
+                "original": 2500,
+                "current": 2000,
                 "promo_until": expected_date,
-                "per_lesson": False,
+                "per_lesson": True,
             },
         )
 
-    def test_get_price_individual_no_subjects_variant2(self) -> None:
+    def test_get_price_individual_no_subjects(self) -> None:
         expected_date = date(date.today().year, 9, 30)
         price = get_application_price("individual", 0)
         self.assertEqual(
             price,
             {
-                "original": 10000,
-                "current": 5000,
+                "original": 2500,
+                "current": 2000,
                 "promo_until": expected_date,
-                "per_lesson": False,
+                "per_lesson": True,
             },
         )
 
@@ -107,13 +107,14 @@ class ApplicationPriceTests(TestCase):
         )
 
     def test_get_price_group_two_subjects_variant3(self) -> None:
+        expected_date = date(date.today().year, 9, 30)
         price = get_application_price("group", 2)
         self.assertEqual(
             price,
             {
-                "original": None,
+                "original": 2500,
                 "current": 2000,
-                "promo_until": None,
+                "promo_until": expected_date,
                 "per_lesson": True,
             },
         )
@@ -200,34 +201,34 @@ class ApplicationPriceTests(TestCase):
         self.assertEqual(
             data,
             {
-                "old": "",
+                "old": "2 500 ₽ за занятие (60 минут)",
                 "current": "2 000 ₽ за занятие (60 минут)",
-                "note": "",
-                "oldDisplay": "none",
-                "noteDisplay": "none",
-            },
-        )
-
-    def test_js_individual_two_subjects_variant2(self) -> None:
-        data = self._run_js("individual", 2)
-        self.assertEqual(
-            data,
-            {
-                "old": "10 000 ₽/мес",
-                "current": "5 000 ₽/мес",
                 "note": "до 30 сентября",
                 "oldDisplay": "",
                 "noteDisplay": "",
             },
         )
 
-    def test_js_individual_no_subjects_variant2(self) -> None:
+    def test_js_individual_two_subjects(self) -> None:
+        data = self._run_js("individual", 2)
+        self.assertEqual(
+            data,
+            {
+                "old": "2 500 ₽ за занятие (60 минут)",
+                "current": "2 000 ₽ за занятие (60 минут)",
+                "note": "до 30 сентября",
+                "oldDisplay": "",
+                "noteDisplay": "",
+            },
+        )
+
+    def test_js_individual_no_subjects(self) -> None:
         data = self._run_js("individual", 0)
         self.assertEqual(
             data,
             {
-                "old": "10 000 ₽/мес",
-                "current": "5 000 ₽/мес",
+                "old": "2 500 ₽ за занятие (60 минут)",
+                "current": "2 000 ₽ за занятие (60 минут)",
                 "note": "до 30 сентября",
                 "oldDisplay": "",
                 "noteDisplay": "",

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -8,12 +8,17 @@ VARIANT1_CURRENT = 3000
 VARIANT1_ORIGINAL = 5000
 VARIANT2_CURRENT = 5000
 VARIANT2_ORIGINAL = 10000
-VARIANT3_PRICE = 2000
+VARIANT3_CURRENT = 2000
+VARIANT3_ORIGINAL = 2500
+
+INDIVIDUAL_ORIGINAL = 2500
+INDIVIDUAL_CURRENT = 2000
+INDIVIDUAL_PER_LESSON = True
 
 class ApplicationPrice(TypedDict):
     current: int
-    original: int | None
-    promo_until: date | None
+    original: int
+    promo_until: date
     per_lesson: bool
 
 
@@ -30,10 +35,10 @@ def get_application_price(
 
     if lesson_type == "individual":
         return {
-            "current": VARIANT2_CURRENT,
-            "original": VARIANT2_ORIGINAL,
+            "current": INDIVIDUAL_CURRENT,
+            "original": INDIVIDUAL_ORIGINAL,
             "promo_until": promo_until,
-            "per_lesson": False,
+            "per_lesson": INDIVIDUAL_PER_LESSON,
         }
 
     if subjects_count == 0:
@@ -49,9 +54,9 @@ def get_application_price(
 
     if lesson_type == "group" and subjects_count == 2:
         return {
-            "current": VARIANT3_PRICE,
-            "original": None,
-            "promo_until": None,
+            "current": VARIANT3_CURRENT,
+            "original": VARIANT3_ORIGINAL,
+            "promo_until": promo_until,
             "per_lesson": True,
         }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -31,7 +31,11 @@ const VARIANT1_CURRENT = 3000;
 const VARIANT1_ORIGINAL = 5000;
 const VARIANT2_CURRENT = 5000;
 const VARIANT2_ORIGINAL = 10000;
-const VARIANT3_PRICE = 2000;
+const VARIANT3_CURRENT = 2000;
+const VARIANT3_ORIGINAL = 2500;
+const INDIVIDUAL_CURRENT = 2000;
+const INDIVIDUAL_ORIGINAL = 2500;
+const INDIVIDUAL_PER_LESSON = true;
 const VARIANT3_UNIT = '₽ за занятие (60 минут)';
 const DEFAULT_UNIT = '₽/мес';
 
@@ -51,17 +55,19 @@ function updatePrice() {
 
   const format = (n) => n.toLocaleString('ru-RU').replace(/\u00A0/g, ' ');
   let currentTotal;
-  let originalTotal = null;
+  let originalTotal;
   let perLesson = false;
 
   if (lessonType === 'individual') {
-    currentTotal = VARIANT2_CURRENT;
-    originalTotal = VARIANT2_ORIGINAL;
+    currentTotal = INDIVIDUAL_CURRENT;
+    originalTotal = INDIVIDUAL_ORIGINAL;
+    perLesson = INDIVIDUAL_PER_LESSON;
   } else if (subjectsCount === 0) {
     currentTotal = VARIANT1_CURRENT;
     originalTotal = VARIANT1_ORIGINAL;
   } else if (lessonType === 'group' && subjectsCount === 2) {
-    currentTotal = VARIANT3_PRICE;
+    currentTotal = VARIANT3_CURRENT;
+    originalTotal = VARIANT3_ORIGINAL;
     perLesson = true;
   } else {
     currentTotal = VARIANT2_CURRENT;
@@ -71,22 +77,12 @@ function updatePrice() {
   const unit = perLesson ? VARIANT3_UNIT : DEFAULT_UNIT;
   priceNewEl.textContent = `${format(currentTotal)} ${unit}`;
   if (priceOldEl) {
-    if (originalTotal) {
-      priceOldEl.textContent = `${format(originalTotal)} ${unit}`;
-      priceOldEl.style.display = '';
-    } else {
-      priceOldEl.textContent = '';
-      priceOldEl.style.display = 'none';
-    }
+    priceOldEl.textContent = `${format(originalTotal)} ${unit}`;
+    priceOldEl.style.display = '';
   }
   if (priceNoteEl) {
-    if (originalTotal) {
-      priceNoteEl.textContent = 'до 30 сентября';
-      priceNoteEl.style.display = '';
-    } else {
-      priceNoteEl.textContent = '';
-      priceNoteEl.style.display = 'none';
-    }
+    priceNoteEl.textContent = 'до 30 сентября';
+    priceNoteEl.style.display = '';
   }
 }
 


### PR DESCRIPTION
## Summary
- add constants for individual per-lesson pricing and variant 3 original cost
- always return original/current prices and promo date
- show old price and promo note in JS and tests

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68be8f6433e4832dbe350b6a4b9f01c1