### PR TITLE
Remove price conditionals and update promo note

### DIFF
--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -7,20 +7,16 @@
     {{ form.as_p }}
     <button type="submit">Записаться</button>
     <p class="application-price">
-      {% if application_price.original %}
-        <span class="price-old">
-          {{ application_price.original }}
-          {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
-        </span>
-      {% endif %}
-      {% if application_price.current %}
-        <span class="price-new">
-          {{ application_price.current }}
-          {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
-        </span>
-      {% endif %}
+      <span class="price-old">
+        {{ application_price.original }}
+        {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+      </span>
+      <span class="price-new">
+        {{ application_price.current }}
+        {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+      </span>
       {% if application_price.promo_until %}
-        <span class="price-note">до {{ application_price.promo_until|date:"d.m.Y" }}</span>
+        <span class="price-note">при записи до {{ application_price.promo_until|date:"d.m.Y" }}</span>
       {% endif %}
     </p>
   </form>

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -63,20 +63,16 @@
           </div>
         </div>
         <p class="application-price">
-          {% if application_price.original %}
-            <span class="price-old">
-              {{ application_price.original }}
-              {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
-            </span>
-          {% endif %}
-          {% if application_price.current %}
-            <span class="price-new">
-              {{ application_price.current }}
-              {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
-            </span>
-          {% endif %}
+          <span class="price-old">
+            {{ application_price.original }}
+            {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+          </span>
+          <span class="price-new">
+            {{ application_price.current }}
+            {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+          </span>
           {% if application_price.promo_until %}
-            <span class="price-note">до {{ application_price.promo_until|date:"d.m.Y" }}</span>
+            <span class="price-note">при записи до {{ application_price.promo_until|date:"d.m.Y" }}</span>
           {% endif %}
         </p>
         <button type="submit" class="btn accent">{% trans "Записаться" %}</button>


### PR DESCRIPTION
## Summary
- Show original and current prices unconditionally in application forms
- Update promo note text to "при записи до" in price display

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68be910fe3b8832d84ebad2604029e44