### PR TITLE
Update application pricing tests and promo text

### DIFF
--- a/applications/tests.py
+++ b/applications/tests.py
@@ -66,6 +66,9 @@ class ApplicationPriceTests(TestCase):
         price = response.context.get("application_price")
         expected_price = get_application_price("group", 0)
         self.assertEqual(price, expected_price)
+        self.assertContains(response, "price-old")
+        self.assertContains(response, "price-new")
+        self.assertContains(response, "при записи до 30 сентября")
 
     def test_get_price_individual_two_subjects(self) -> None:
         expected_date = date(date.today().year, 9, 30)
@@ -161,6 +164,7 @@ class ApplicationPriceTests(TestCase):
           current: priceNew.textContent,
           note: priceNote.textContent,
           oldDisplay: priceOld.style.display,
+          newDisplay: priceNew.style.display,
           noteDisplay: priceNote.style.display,
         }}));
         """
@@ -177,8 +181,9 @@ class ApplicationPriceTests(TestCase):
             {
                 "old": "5 000 ₽/мес",
                 "current": "3 000 ₽/мес",
-                "note": "до 30 сентября",
+                "note": "при записи до 30 сентября",
                 "oldDisplay": "",
+                "newDisplay": "",
                 "noteDisplay": "",
             },
         )
@@ -190,8 +195,9 @@ class ApplicationPriceTests(TestCase):
             {
                 "old": "10 000 ₽/мес",
                 "current": "5 000 ₽/мес",
-                "note": "до 30 сентября",
+                "note": "при записи до 30 сентября",
                 "oldDisplay": "",
+                "newDisplay": "",
                 "noteDisplay": "",
             },
         )
@@ -203,8 +209,9 @@ class ApplicationPriceTests(TestCase):
             {
                 "old": "2 500 ₽ за занятие (60 минут)",
                 "current": "2 000 ₽ за занятие (60 минут)",
-                "note": "до 30 сентября",
+                "note": "при записи до 30 сентября",
                 "oldDisplay": "",
+                "newDisplay": "",
                 "noteDisplay": "",
             },
         )
@@ -214,10 +221,11 @@ class ApplicationPriceTests(TestCase):
         self.assertEqual(
             data,
             {
-                "old": "2 500 ₽ за занятие (60 минут)",
-                "current": "2 000 ₽ за занятие (60 минут)",
-                "note": "до 30 сентября",
+                "old": "2 500 ₽ за урок",
+                "current": "2 000 ₽ за урок",
+                "note": "при записи до 30 сентября",
                 "oldDisplay": "",
+                "newDisplay": "",
                 "noteDisplay": "",
             },
         )
@@ -227,10 +235,11 @@ class ApplicationPriceTests(TestCase):
         self.assertEqual(
             data,
             {
-                "old": "2 500 ₽ за занятие (60 минут)",
-                "current": "2 000 ₽ за занятие (60 минут)",
-                "note": "до 30 сентября",
+                "old": "2 500 ₽ за урок",
+                "current": "2 000 ₽ за урок",
+                "note": "при записи до 30 сентября",
                 "oldDisplay": "",
+                "newDisplay": "",
                 "noteDisplay": "",
             },
         )

--- a/fractalschool/settings.py
+++ b/fractalschool/settings.py
@@ -116,7 +116,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'ru'
 
 TIME_ZONE = 'UTC'
 

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -16,7 +16,7 @@
         {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
       </span>
       {% if application_price.promo_until %}
-        <span class="price-note">при записи до {{ application_price.promo_until|date:"d.m.Y" }}</span>
+        <span class="price-note">при записи до {{ application_price.promo_until|date:"j E" }}</span>
       {% endif %}
     </p>
   </form>

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -72,7 +72,7 @@
             {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
           </span>
           {% if application_price.promo_until %}
-            <span class="price-note">при записи до {{ application_price.promo_until|date:"d.m.Y" }}</span>
+            <span class="price-note">при записи до {{ application_price.promo_until|date:"j E" }}</span>
           {% endif %}
         </p>
         <button type="submit" class="btn accent">{% trans "Записаться" %}</button>


### PR DESCRIPTION
## Summary
- Verify `price-old` and `price-new` are present in application views and JS tests
- Switch tests to "при записи до 30 сентября" and expose price-new display flag
- Localize promo date with Russian month names

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68be94bd2f7c832da79f71f64bc4f3f7