### PR TITLE
Switch site to cyber font and inherit on forms

### DIFF
--- a/static/css/cyber.css
+++ b/static/css/cyber.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap');
+
 :root{
   --bg:#0a0f0d;           /* глубокий тёмный */
   --panel:#0f1613;        /* тёмная панель */
@@ -12,7 +14,8 @@
 }
 html,body{height:100%;}
 body{
-  margin:0; font: 16px/1.5 Consolas, "JetBrains Mono", Menlo, Monaco, "SFMono-Regular", monospace;
+  margin:0;
+  font: 16px/1.5 'JetBrains Mono', Consolas, Menlo, Monaco, 'SFMono-Regular', monospace;
   background: radial-gradient(1200px 600px at 10% 0%, #0b1310 0%, var(--bg) 45%) fixed;
   color:var(--text);
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -3,7 +3,15 @@
 }
 * { box-sizing: border-box; }
 html, body { height: 100%; }
-body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif; background: var(--bg); color: var(--text); }
+body {
+  margin: 0;
+  font-family: 'JetBrains Mono', Consolas, Menlo, Monaco, 'SFMono-Regular', monospace;
+  background: var(--bg);
+  color: var(--text);
+}
+input, select, textarea, button {
+  font-family: inherit;
+}
 a { color: inherit; text-decoration: none; }
 
 /* Header */


### PR DESCRIPTION
## Summary
- load JetBrains Mono from Google Fonts and apply as site's default monospace style
- ensure form controls inherit the global cyber font

## Testing
- `python manage.py collectstatic --noinput`
- `python manage.py migrate`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68be97ba03ac832d8431c4c3c33d0545