### PR TITLE
Treat single subject as VARIANT1 pricing

### DIFF
--- a/applications/tests.py
+++ b/applications/tests.py
@@ -96,14 +96,14 @@ class ApplicationPriceTests(TestCase):
             },
         )
 
-    def test_get_price_group_one_subject_variant2(self) -> None:
+    def test_get_price_group_one_subject_variant1(self) -> None:
         expected_date = date(date.today().year, 9, 30)
         price = get_application_price("group", 1)
         self.assertEqual(
             price,
             {
-                "original": 10000,
-                "current": 5000,
+                "original": 5000,
+                "current": 3000,
                 "promo_until": expected_date,
                 "per_lesson": False,
             },
@@ -188,13 +188,13 @@ class ApplicationPriceTests(TestCase):
             },
         )
 
-    def test_js_group_one_subject_variant2(self) -> None:
+    def test_js_group_one_subject_variant1(self) -> None:
         data = self._run_js("group", 1)
         self.assertEqual(
             data,
             {
-                "old": "10 000 ₽/мес",
-                "current": "5 000 ₽/мес",
+                "old": "5 000 ₽/мес",
+                "current": "3 000 ₽/мес",
                 "note": "при записи до 30 сентября",
                 "oldDisplay": "",
                 "newDisplay": "",

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -6,8 +6,6 @@ from typing import TypedDict
 # Pricing variants
 VARIANT1_CURRENT = 3000
 VARIANT1_ORIGINAL = 5000
-VARIANT2_CURRENT = 5000
-VARIANT2_ORIGINAL = 10000
 VARIANT3_CURRENT = 2000
 VARIANT3_ORIGINAL = 2500
 
@@ -41,7 +39,7 @@ def get_application_price(
             "per_lesson": INDIVIDUAL_PER_LESSON,
         }
 
-    if subjects_count == 0:
+    if subjects_count <= 1:
         return {
             "current": VARIANT1_CURRENT,
             "original": VARIANT1_ORIGINAL,
@@ -60,9 +58,4 @@ def get_application_price(
             "per_lesson": True,
         }
 
-    return {
-        "current": VARIANT2_CURRENT,
-        "original": VARIANT2_ORIGINAL,
-        "promo_until": promo_until,
-        "per_lesson": False,
-    }
+    return None

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -29,8 +29,6 @@ function setMode(mode) {
 
 const VARIANT1_CURRENT = 3000;
 const VARIANT1_ORIGINAL = 5000;
-const VARIANT2_CURRENT = 5000;
-const VARIANT2_ORIGINAL = 10000;
 const VARIANT3_CURRENT = 2000;
 const VARIANT3_ORIGINAL = 2500;
 const INDIVIDUAL_CURRENT = 2000;
@@ -62,16 +60,13 @@ function updatePrice() {
     currentTotal = INDIVIDUAL_CURRENT;
     originalTotal = INDIVIDUAL_ORIGINAL;
     unit = INDIVIDUAL_UNIT;
-  } else if (subjectsCount === 0) {
+  } else if (subjectsCount <= 1) {
     currentTotal = VARIANT1_CURRENT;
     originalTotal = VARIANT1_ORIGINAL;
   } else if (lessonType === 'group' && subjectsCount === 2) {
     currentTotal = VARIANT3_CURRENT;
     originalTotal = VARIANT3_ORIGINAL;
     unit = VARIANT3_UNIT;
-  } else {
-    currentTotal = VARIANT2_CURRENT;
-    originalTotal = VARIANT2_ORIGINAL;
   }
 
   priceOldEl.textContent = `${format(originalTotal)} ${unit}`;


### PR DESCRIPTION
## Summary
- Treat one subject the same as zero subjects in pricing logic
- Drop VARIANT2 branch from JS and backend utils
- Update tests to expect VARIANT1 price for one subject

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68be9ad2c308832d86afa50ec87967f7