### PR TITLE
Fix pricing toggle reliability

### DIFF
--- a/applications/utils.py
+++ b/applications/utils.py
@@ -29,6 +29,9 @@ def get_application_price(
     if subjects_count < 0:
         return None
 
+    if lesson_type not in {"individual", "group"}:
+        return None
+
     promo_until = date(date.today().year, 9, 30)
 
     if lesson_type == "individual":
@@ -39,18 +42,7 @@ def get_application_price(
             "per_lesson": INDIVIDUAL_PER_LESSON,
         }
 
-    if subjects_count <= 1:
-        return {
-            "current": VARIANT1_CURRENT,
-            "original": VARIANT1_ORIGINAL,
-            "promo_until": promo_until,
-            "per_lesson": False,
-        }
-
-    if lesson_type not in {"individual", "group"}:
-        return None
-
-    if lesson_type == "group" and subjects_count == 2:
+    if subjects_count == 2:
         return {
             "current": VARIANT3_CURRENT,
             "original": VARIANT3_ORIGINAL,
@@ -58,4 +50,9 @@ def get_application_price(
             "per_lesson": True,
         }
 
-    return None
+    return {
+        "current": VARIANT1_CURRENT,
+        "original": VARIANT1_ORIGINAL,
+        "promo_until": promo_until,
+        "per_lesson": False,
+    }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -46,7 +46,7 @@ function updatePrice() {
   const priceNoteEl = document.querySelector('.price-note');
   if (!lessonTypeEl || !subject1El || !subject2El || !priceOldEl || !priceNewEl || !priceNoteEl) return;
 
-  const lessonType = lessonTypeEl.value || 'group';
+  const lessonType = lessonTypeEl.value === 'individual' ? 'individual' : 'group';
   let subjectsCount = 0;
   if (subject1El.value) subjectsCount += 1;
   if (subject2El.value) subjectsCount += 1;
@@ -60,13 +60,13 @@ function updatePrice() {
     currentTotal = INDIVIDUAL_CURRENT;
     originalTotal = INDIVIDUAL_ORIGINAL;
     unit = INDIVIDUAL_UNIT;
-  } else if (subjectsCount <= 1) {
-    currentTotal = VARIANT1_CURRENT;
-    originalTotal = VARIANT1_ORIGINAL;
-  } else if (lessonType === 'group' && subjectsCount === 2) {
+  } else if (subjectsCount === 2) {
     currentTotal = VARIANT3_CURRENT;
     originalTotal = VARIANT3_ORIGINAL;
     unit = VARIANT3_UNIT;
+  } else {
+    currentTotal = VARIANT1_CURRENT;
+    originalTotal = VARIANT1_ORIGINAL;
   }
 
   priceOldEl.textContent = `${format(originalTotal)} ${unit}`;
@@ -75,7 +75,9 @@ function updatePrice() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  setMode('group');
+  const input = document.getElementById('id_lesson_type');
+  const mode = input && input.value ? input.value : 'group';
+  setMode(mode);
   ['id_grade', 'id_subject1', 'id_subject2', 'id_lesson_type'].forEach((id) => {
     const el = document.getElementById(id);
     if (el) {


### PR DESCRIPTION
## Summary
- Ensure lesson pricing logic checks lesson type explicitly
- Sync client-side mode switch with hidden lesson type input

## Testing
- `python manage.py test applications`


------
https://chatgpt.com/codex/tasks/task_e_68be9d211d84832da748dc1d2daa1518