### PR TITLE
Update pricing variants and sync frontend

### DIFF
--- a/applications/utils.py
+++ b/applications/utils.py
@@ -6,12 +6,12 @@ from typing import TypedDict
 # Pricing variants
 VARIANT1_CURRENT = 3000
 VARIANT1_ORIGINAL = 5000
+VARIANT2_CURRENT = 5000
+VARIANT2_ORIGINAL = 10000
 VARIANT3_CURRENT = 2000
 VARIANT3_ORIGINAL = 2500
 
-INDIVIDUAL_ORIGINAL = 2500
-INDIVIDUAL_CURRENT = 2000
-INDIVIDUAL_PER_LESSON = True
+PROMO_UNTIL = date(2025, 9, 30)
 
 class ApplicationPrice(TypedDict):
     current: int
@@ -32,27 +32,33 @@ def get_application_price(
     if lesson_type not in {"individual", "group"}:
         return None
 
-    promo_until = date(date.today().year, 9, 30)
-
     if lesson_type == "individual":
         return {
-            "current": INDIVIDUAL_CURRENT,
-            "original": INDIVIDUAL_ORIGINAL,
-            "promo_until": promo_until,
-            "per_lesson": INDIVIDUAL_PER_LESSON,
+            "current": VARIANT2_CURRENT,
+            "original": VARIANT2_ORIGINAL,
+            "promo_until": PROMO_UNTIL,
+            "per_lesson": False,
+        }
+
+    if subjects_count == 1:
+        return {
+            "current": VARIANT2_CURRENT,
+            "original": VARIANT2_ORIGINAL,
+            "promo_until": PROMO_UNTIL,
+            "per_lesson": False,
         }
 
     if subjects_count == 2:
         return {
             "current": VARIANT3_CURRENT,
             "original": VARIANT3_ORIGINAL,
-            "promo_until": promo_until,
+            "promo_until": PROMO_UNTIL,
             "per_lesson": True,
         }
 
     return {
         "current": VARIANT1_CURRENT,
         "original": VARIANT1_ORIGINAL,
-        "promo_until": promo_until,
+        "promo_until": PROMO_UNTIL,
         "per_lesson": False,
     }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -6,36 +6,21 @@ document.addEventListener('click', (e) => {
 });
 
 function setMode(mode) {
-  const individualBtn = document.getElementById('mode-individual');
-  const groupBtn = document.getElementById('mode-group');
   const input = document.getElementById('id_lesson_type');
-  if (!individualBtn || !groupBtn || !input) return;
-
-  if (mode === 'individual') {
-    individualBtn.classList.add('active');
-    individualBtn.setAttribute('aria-selected', 'true');
-    groupBtn.classList.remove('active');
-    groupBtn.setAttribute('aria-selected', 'false');
-  } else {
-    groupBtn.classList.add('active');
-    groupBtn.setAttribute('aria-selected', 'true');
-    individualBtn.classList.remove('active');
-    individualBtn.setAttribute('aria-selected', 'false');
-  }
-
+  if (!input) return;
   input.value = mode;
   updatePrice();
 }
 
 const VARIANT1_CURRENT = 3000;
 const VARIANT1_ORIGINAL = 5000;
+const VARIANT1_UNIT = '₽/мес';
+const VARIANT2_CURRENT = 5000;
+const VARIANT2_ORIGINAL = 10000;
+const VARIANT2_UNIT = '₽/мес';
 const VARIANT3_CURRENT = 2000;
 const VARIANT3_ORIGINAL = 2500;
-const INDIVIDUAL_CURRENT = 2000;
-const INDIVIDUAL_ORIGINAL = 2500;
 const VARIANT3_UNIT = '₽ за занятие (60 минут)';
-const INDIVIDUAL_UNIT = '₽ за урок';
-const DEFAULT_UNIT = '₽/мес';
 
 function updatePrice() {
   const lessonTypeEl = document.getElementById('id_lesson_type');
@@ -47,19 +32,20 @@ function updatePrice() {
   if (!lessonTypeEl || !subject1El || !subject2El || !priceOldEl || !priceNewEl || !priceNoteEl) return;
 
   const lessonType = lessonTypeEl.value === 'individual' ? 'individual' : 'group';
+  const isSelected = (el) => !!(el && el.value && el.value !== 'none');
   let subjectsCount = 0;
-  if (subject1El.value) subjectsCount += 1;
-  if (subject2El.value) subjectsCount += 1;
+  if (isSelected(subject1El)) subjectsCount += 1;
+  if (isSelected(subject2El)) subjectsCount += 1;
 
   const format = (n) => n.toLocaleString('ru-RU').replace(/\u00A0/g, ' ');
   let currentTotal;
   let originalTotal;
-  let unit = DEFAULT_UNIT;
+  let unit;
 
-  if (lessonType === 'individual') {
-    currentTotal = INDIVIDUAL_CURRENT;
-    originalTotal = INDIVIDUAL_ORIGINAL;
-    unit = INDIVIDUAL_UNIT;
+  if (lessonType === 'individual' || subjectsCount === 1) {
+    currentTotal = VARIANT2_CURRENT;
+    originalTotal = VARIANT2_ORIGINAL;
+    unit = VARIANT2_UNIT;
   } else if (subjectsCount === 2) {
     currentTotal = VARIANT3_CURRENT;
     originalTotal = VARIANT3_ORIGINAL;
@@ -67,6 +53,7 @@ function updatePrice() {
   } else {
     currentTotal = VARIANT1_CURRENT;
     originalTotal = VARIANT1_ORIGINAL;
+    unit = VARIANT1_UNIT;
   }
 
   priceOldEl.textContent = `${format(originalTotal)} ${unit}`;
@@ -75,14 +62,10 @@ function updatePrice() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  const input = document.getElementById('id_lesson_type');
-  const mode = input && input.value ? input.value : 'group';
-  setMode(mode);
+  updatePrice();
   ['id_grade', 'id_subject1', 'id_subject2', 'id_lesson_type'].forEach((id) => {
     const el = document.getElementById(id);
-    if (el) {
-      el.addEventListener('change', updatePrice);
-    }
+    if (el) el.addEventListener('change', updatePrice);
   });
 });
 


### PR DESCRIPTION
## Summary
- expand pricing constants to cover three variants and fixed promo date
- adjust application price logic for variant selection and per-lesson flags
- mirror pricing logic in frontend and trigger updates on selection changes

## Testing
- `pytest` *(fails: AppRegistryNotReady: Apps aren't loaded yet)*
- `DJANGO_SETTINGS_MODULE=fractalschool.settings pytest` *(fails: Apps aren't loaded yet)*


------
https://chatgpt.com/codex/tasks/task_e_68bea54aab20832daf1664fa8dbee4ee