### PR TITLE
Fix HomeView price call and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,12 @@ $$w_t = w_{t-1} e^{-\lambda \Delta t}$$
 предметы. Форма `ApplicationForm` используется для создания заявок через
 веб-интерфейс.
 
+Функция `get_application_price` вычисляет стоимость в зависимости от количества
+выбранных предметов. Например:
+
+```python
+from applications.utils import get_application_price
+
+price = get_application_price(0)  # стоимость при отсутствии выбранных предметов
+```
+

--- a/fractalschool/tests.py
+++ b/fractalschool/tests.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from applications.utils import get_application_price
+
+
+class HomeViewTests(TestCase):
+    def test_default_price_in_context(self) -> None:
+        response = self.client.get(reverse("home"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context.get("application_price"), get_application_price(0)
+        )
+        self.assertContains(response, "price-old")
+        self.assertContains(response, "price-new")
+        self.assertContains(response, "при записи до 30 сентября")

--- a/fractalschool/views.py
+++ b/fractalschool/views.py
@@ -11,6 +11,6 @@ class HomeView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["form"] = ApplicationForm()
-        context["application_price"] = get_application_price("group", 0)
+        context["application_price"] = get_application_price(0)
         return context
 


### PR DESCRIPTION
## Summary
- correct `HomeView` to request application price using subjects count only
- document `get_application_price` usage in README
- add test for home page price context

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bfb2f148fc832da770fe1989ce1d92