### PR TITLE
Remove subject-based pricing variants and unify price display

### DIFF
--- a/applications/tests.py
+++ b/applications/tests.py
@@ -63,48 +63,25 @@ class ApplicationPriceTests(TestCase):
         price = response.context.get("application_price")
         expected_price = get_application_price(0)
         self.assertEqual(price, expected_price)
+        self.assertNotIn("per_lesson", price)
         self.assertContains(response, "price-old")
         self.assertContains(response, "price-new")
         self.assertContains(response, "при записи до 30 сентября")
 
-    def test_get_price_group_one_subject_variant1(self) -> None:
+    def test_get_price_same_for_any_subjects(self) -> None:
         expected_date = date(date.today().year, 9, 30)
-        price = get_application_price(1)
-        self.assertEqual(
-            price,
-            {
-                "original": 5000,
-                "current": 3000,
-                "promo_until": expected_date,
-                "per_lesson": False,
-            },
-        )
-
-    def test_get_price_group_two_subjects_variant3(self) -> None:
-        expected_date = date(date.today().year, 9, 30)
-        price = get_application_price(2)
-        self.assertEqual(
-            price,
-            {
-                "original": 2500,
-                "current": 2000,
-                "promo_until": expected_date,
-                "per_lesson": True,
-            },
-        )
-
-    def test_get_price_no_subjects_variant1(self) -> None:
-        expected_date = date(date.today().year, 9, 30)
-        price = get_application_price(0)
-        self.assertEqual(
-            price,
-            {
-                "original": 5000,
-                "current": 3000,
-                "promo_until": expected_date,
-                "per_lesson": False,
-            },
-        )
+        for subjects in [0, 1, 2]:
+            with self.subTest(subjects=subjects):
+                price = get_application_price(subjects)
+                self.assertEqual(
+                    price,
+                    {
+                        "original": 5000,
+                        "current": 3000,
+                        "promo_until": expected_date,
+                    },
+                )
+                self.assertNotIn("per_lesson", price)
 
     def _run_js_values(self, subject1: str, subject2: str):
         import json
@@ -147,47 +124,19 @@ class ApplicationPriceTests(TestCase):
         subject2 = "1" if subject_count >= 2 else ""
         return self._run_js_values(subject1, subject2)
 
-    def test_js_no_subjects_variant1(self) -> None:
-        data = self._run_js(0)
-        self.assertEqual(
-            data,
-            {
-                "old": "5 000 ₽/мес",
-                "current": "3 000 ₽/мес",
-                "note": "при записи до 30 сентября",
-                "oldDisplay": "",
-                "newDisplay": "",
-                "noteDisplay": "",
-            },
-        )
-
-    def test_js_group_one_subject_variant1(self) -> None:
-        data = self._run_js(1)
-        self.assertEqual(
-            data,
-            {
-                "old": "5 000 ₽/мес",
-                "current": "3 000 ₽/мес",
-                "note": "при записи до 30 сентября",
-                "oldDisplay": "",
-                "newDisplay": "",
-                "noteDisplay": "",
-            },
-        )
-
-    def test_js_group_two_subjects_variant3(self) -> None:
-        data = self._run_js(2)
-        self.assertEqual(
-            data,
-            {
-                "old": "2 500 ₽ за занятие (60 минут)",
-                "current": "2 000 ₽ за занятие (60 минут)",
-                "note": "при записи до 30 сентября",
-                "oldDisplay": "",
-                "newDisplay": "",
-                "noteDisplay": "",
-            },
-        )
+    def test_js_price_same_for_any_subjects(self) -> None:
+        expected = {
+            "old": "5 000 ₽/мес",
+            "current": "3 000 ₽/мес",
+            "note": "при записи до 30 сентября",
+            "oldDisplay": "",
+            "newDisplay": "",
+            "noteDisplay": "",
+        }
+        for subjects in [0, 1, 2]:
+            with self.subTest(subjects=subjects):
+                data = self._run_js(subjects)
+                self.assertEqual(data, expected)
 
 
     def test_js_placeholder_values_not_counted(self) -> None:

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -3,38 +3,30 @@ from __future__ import annotations
 from datetime import date
 from typing import TypedDict
 
-# Pricing variants
+# Pricing variant
 VARIANT1_CURRENT = 3000
 VARIANT1_ORIGINAL = 5000
-VARIANT3_CURRENT = 2000
-VARIANT3_ORIGINAL = 2500
 
 PROMO_UNTIL = date(2025, 9, 30)
+
 
 class ApplicationPrice(TypedDict):
     current: int
     original: int
     promo_until: date
-    per_lesson: bool
 
 
 def get_application_price(subjects_count: int) -> ApplicationPrice | None:
-    """Return application price based on subjects count."""
+    """Return application price.
+
+    Currently pricing does not depend on the number of subjects.
+    """
 
     if subjects_count < 0:
         return None
-
-    if subjects_count == 2:
-        return {
-            "current": VARIANT3_CURRENT,
-            "original": VARIANT3_ORIGINAL,
-            "promo_until": PROMO_UNTIL,
-            "per_lesson": True,
-        }
 
     return {
         "current": VARIANT1_CURRENT,
         "original": VARIANT1_ORIGINAL,
         "promo_until": PROMO_UNTIL,
-        "per_lesson": False,
     }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -8,42 +8,17 @@ document.addEventListener('click', (e) => {
 const VARIANT1_CURRENT = 3000;
 const VARIANT1_ORIGINAL = 5000;
 const VARIANT1_UNIT = '₽/мес';
-const VARIANT3_CURRENT = 2000;
-const VARIANT3_ORIGINAL = 2500;
-const VARIANT3_UNIT = '₽ за занятие (60 минут)';
-
-function isChosen(selectEl) {
-  if (!selectEl) return false;
-  const value = (selectEl.value || '').toString().trim().toLowerCase();
-  return value !== '' && value !== 'none' && value !== '0';
-}
 
 function updatePrice() {
-  const subject1El = document.getElementById('id_subject1');
-  const subject2El = document.getElementById('id_subject2');
   const priceOldEl = document.querySelector('.price-old');
   const priceNewEl = document.querySelector('.price-new');
   const priceNoteEl = document.querySelector('.price-note');
-  if (!subject1El || !subject2El || !priceOldEl || !priceNewEl) return;
-
-  let subjectsCount = 0;
-  if (isChosen(subject1El)) subjectsCount += 1;
-  if (isChosen(subject2El)) subjectsCount += 1;
+  if (!priceOldEl || !priceNewEl) return;
 
   const format = (n) => n.toLocaleString('ru-RU').replace(/\u00A0/g, ' ');
-  let currentTotal;
-  let originalTotal;
-  let unit;
-
-  if (subjectsCount === 2) {
-    currentTotal = VARIANT3_CURRENT;
-    originalTotal = VARIANT3_ORIGINAL;
-    unit = VARIANT3_UNIT;
-  } else {
-    currentTotal = VARIANT1_CURRENT;
-    originalTotal = VARIANT1_ORIGINAL;
-    unit = VARIANT1_UNIT;
-  }
+  const currentTotal = VARIANT1_CURRENT;
+  const originalTotal = VARIANT1_ORIGINAL;
+  const unit = VARIANT1_UNIT;
 
   priceOldEl.textContent = `${format(originalTotal)} ${unit}`;
   priceNewEl.textContent = `${format(currentTotal)} ${unit}`;
@@ -59,5 +34,5 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 if (typeof module !== 'undefined') {
-  module.exports = { updatePrice, isChosen };
+  module.exports = { updatePrice };
 }

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -8,12 +8,10 @@
     <button type="submit">Записаться</button>
     <p class="application-price">
       <span class="price-old">
-        {{ application_price.original }}
-        {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+        {{ application_price.original }} ₽/мес
       </span>
       <span class="price-new">
-        {{ application_price.current }}
-        {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+        {{ application_price.current }} ₽/мес
       </span>
       <span class="price-note">
         {% if application_price.promo_until %}

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -48,12 +48,10 @@
         </p>
         <p class="application-price">
           <span class="price-old">
-            {{ application_price.original }}
-            {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+            {{ application_price.original }} ₽/мес
           </span>
           <span class="price-new">
-            {{ application_price.current }}
-            {% if application_price.per_lesson %}₽ за занятие (60 минут){% else %}₽/мес{% endif %}
+            {{ application_price.current }} ₽/мес
           </span>
           <span class="price-note">
             {% if application_price.promo_until %}


### PR DESCRIPTION
## Summary
- Simplify application pricing: single variant at 5 000 ₽/мес → 3 000 ₽/мес
- Remove per-lesson pricing logic from utils, templates, JS, and tests
- Adjust tests and frontend code to always show monthly pricing

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bffa19bb60832d870c725a0f6b31ad