### PR TITLE
Add pricing for two subjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,6 @@ $$w_t = w_{t-1} e^{-\lambda \Delta t}$$
 from applications.utils import get_application_price
 
 price = get_application_price(0)  # стоимость при отсутствии выбранных предметов
+price_two = get_application_price(2)  # стоимость при выборе двух предметов
 ```
 

--- a/applications/tests.py
+++ b/applications/tests.py
@@ -68,19 +68,17 @@ class ApplicationPriceTests(TestCase):
         self.assertContains(response, "price-new")
         self.assertContains(response, "при записи до 30 сентября")
 
-    def test_get_price_same_for_any_subjects(self) -> None:
+    def test_get_price_changes_with_subjects(self) -> None:
         expected_date = date(date.today().year, 9, 30)
-        for subjects in [0, 1, 2]:
+        cases = {
+            0: {"original": 5000, "current": 3000, "promo_until": expected_date},
+            1: {"original": 5000, "current": 3000, "promo_until": expected_date},
+            2: {"original": 10000, "current": 5000, "promo_until": expected_date},
+        }
+        for subjects, expected in cases.items():
             with self.subTest(subjects=subjects):
                 price = get_application_price(subjects)
-                self.assertEqual(
-                    price,
-                    {
-                        "original": 5000,
-                        "current": 3000,
-                        "promo_until": expected_date,
-                    },
-                )
+                self.assertEqual(price, expected)
                 self.assertNotIn("per_lesson", price)
 
     def _run_js_values(self, subject1: str, subject2: str):
@@ -124,16 +122,34 @@ class ApplicationPriceTests(TestCase):
         subject2 = "1" if subject_count >= 2 else ""
         return self._run_js_values(subject1, subject2)
 
-    def test_js_price_same_for_any_subjects(self) -> None:
-        expected = {
-            "old": "5 000 ₽/мес",
-            "current": "3 000 ₽/мес",
-            "note": "при записи до 30 сентября",
-            "oldDisplay": "",
-            "newDisplay": "",
-            "noteDisplay": "",
+    def test_js_price_changes_with_subjects(self) -> None:
+        cases = {
+            0: {
+                "old": "5 000 ₽/мес",
+                "current": "3 000 ₽/мес",
+                "note": "при записи до 30 сентября",
+                "oldDisplay": "",
+                "newDisplay": "",
+                "noteDisplay": "",
+            },
+            1: {
+                "old": "5 000 ₽/мес",
+                "current": "3 000 ₽/мес",
+                "note": "при записи до 30 сентября",
+                "oldDisplay": "",
+                "newDisplay": "",
+                "noteDisplay": "",
+            },
+            2: {
+                "old": "10 000 ₽/мес",
+                "current": "5 000 ₽/мес",
+                "note": "за два предмета при записи до 30 сентября",
+                "oldDisplay": "",
+                "newDisplay": "",
+                "noteDisplay": "",
+            },
         }
-        for subjects in [0, 1, 2]:
+        for subjects, expected in cases.items():
             with self.subTest(subjects=subjects):
                 data = self._run_js(subjects)
                 self.assertEqual(data, expected)

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from datetime import date
 from typing import TypedDict
 
-# Pricing variant
+# Pricing variants
 VARIANT1_CURRENT = 3000
 VARIANT1_ORIGINAL = 5000
+
+VARIANT2_CURRENT = 5000
+VARIANT2_ORIGINAL = 10000
 
 PROMO_UNTIL = date(2025, 9, 30)
 
@@ -17,16 +20,20 @@ class ApplicationPrice(TypedDict):
 
 
 def get_application_price(subjects_count: int) -> ApplicationPrice | None:
-    """Return application price.
-
-    Currently pricing does not depend on the number of subjects.
-    """
+    """Return application price based on the number of subjects."""
 
     if subjects_count < 0:
         return None
 
+    if subjects_count >= 2:
+        current = VARIANT2_CURRENT
+        original = VARIANT2_ORIGINAL
+    else:
+        current = VARIANT1_CURRENT
+        original = VARIANT1_ORIGINAL
+
     return {
-        "current": VARIANT1_CURRENT,
-        "original": VARIANT1_ORIGINAL,
+        "current": current,
+        "original": original,
         "promo_until": PROMO_UNTIL,
     }

--- a/applications/views.py
+++ b/applications/views.py
@@ -41,7 +41,6 @@ class ApplicationCreateView(FormView):
                 subjects_count += 1
             if data.get("subject2"):
                 subjects_count += 1
-        context["application_price"] = get_application_price(
-            subjects_count,
-        )
+        context["subjects_count"] = subjects_count
+        context["application_price"] = get_application_price(subjects_count)
         return context

--- a/fractalschool/tests.py
+++ b/fractalschool/tests.py
@@ -14,3 +14,13 @@ class HomeViewTests(TestCase):
         self.assertContains(response, "price-old")
         self.assertContains(response, "price-new")
         self.assertContains(response, "при записи до 30 сентября")
+
+    def test_price_changes_with_second_subject(self) -> None:
+        response = self.client.get(
+            reverse("home"), {"subject1": "1", "subject2": "1"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context.get("application_price"), get_application_price(2)
+        )
+        self.assertContains(response, "за два предмета")

--- a/fractalschool/views.py
+++ b/fractalschool/views.py
@@ -10,7 +10,17 @@ class HomeView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["form"] = ApplicationForm()
-        context["application_price"] = get_application_price(0)
+        form = ApplicationForm(self.request.GET or None)
+        context["form"] = form
+
+        subjects_count = 0
+        data = form.data if form.is_bound else form.initial
+        if data.get("subject1"):
+            subjects_count += 1
+        if data.get("subject2"):
+            subjects_count += 1
+
+        context["subjects_count"] = subjects_count
+        context["application_price"] = get_application_price(subjects_count)
         return context
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -9,20 +9,39 @@ const VARIANT1_CURRENT = 3000;
 const VARIANT1_ORIGINAL = 5000;
 const VARIANT1_UNIT = '₽/мес';
 
+const VARIANT2_CURRENT = 5000;
+const VARIANT2_ORIGINAL = 10000;
+
+function countSubjects() {
+  return ['id_subject1', 'id_subject2'].reduce((count, id) => {
+    const el = document.getElementById(id);
+    const value = el && el.value;
+    if (value && value !== '0' && value !== 'none') {
+      return count + 1;
+    }
+    return count;
+  }, 0);
+}
+
 function updatePrice() {
   const priceOldEl = document.querySelector('.price-old');
   const priceNewEl = document.querySelector('.price-new');
   const priceNoteEl = document.querySelector('.price-note');
-  if (!priceOldEl || !priceNewEl) return;
+  if (!priceOldEl || !priceNewEl || !priceNoteEl) return;
 
   const format = (n) => n.toLocaleString('ru-RU').replace(/\u00A0/g, ' ');
-  const currentTotal = VARIANT1_CURRENT;
-  const originalTotal = VARIANT1_ORIGINAL;
   const unit = VARIANT1_UNIT;
+
+  const subjects = countSubjects();
+  const isVariant2 = subjects >= 2;
+
+  const currentTotal = isVariant2 ? VARIANT2_CURRENT : VARIANT1_CURRENT;
+  const originalTotal = isVariant2 ? VARIANT2_ORIGINAL : VARIANT1_ORIGINAL;
+  const notePrefix = isVariant2 ? 'за два предмета ' : '';
 
   priceOldEl.textContent = `${format(originalTotal)} ${unit}`;
   priceNewEl.textContent = `${format(currentTotal)} ${unit}`;
-  priceNoteEl.textContent = 'при записи до 30 сентября';
+  priceNoteEl.textContent = `${notePrefix}при записи до 30 сентября`;
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -14,6 +14,7 @@
         {{ application_price.current }} ₽/мес
       </span>
       <span class="price-note">
+        {% if subjects_count >= 2 %}за два предмета {% endif %}
         {% if application_price.promo_until %}
           при записи до {{ application_price.promo_until|date:"j E" }}
         {% endif %}

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -54,6 +54,7 @@
             {{ application_price.current }} ₽/мес
           </span>
           <span class="price-note">
+            {% if subjects_count >= 2 %}за два предмета {% endif %}
             {% if application_price.promo_until %}
               при записи до {{ application_price.promo_until|date:"j E" }}
             {% endif %}


### PR DESCRIPTION
## Summary
- add second pricing tier for two-subject applications and expose subject count to templates
- update client-side price calculation to switch between one- and two-subject prices
- show "за два предмета" note in templates when two subjects are selected

## Testing
- `python manage.py test applications.tests fractalschool.tests`


------
https://chatgpt.com/codex/tasks/task_e_68c00fc32a74832dbee19382a9bde003