### PR TITLE
Use site background for large sections

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -60,11 +60,9 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 }
 
 .block--futuristic {
-  background: linear-gradient(135deg, var(--card), color-mix(in srgb, var(--accent) 5%, transparent));
-  border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border));
-  box-shadow:
-    0 0 12px color-mix(in srgb, var(--accent) 25%, transparent),
-    0 0 24px color-mix(in srgb, var(--accent-2) 15%, transparent);
+  background: var(--bg);
+  border: none;
+  box-shadow: none;
 }
 
 .section-title {


### PR DESCRIPTION
## Summary
- make `.block--futuristic` sections use the page background and drop border/shadow

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c0169da10c832da6e4419f75617cd9