### PR TITLE
feat: add neon border effect

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -69,6 +69,26 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 
 }
 
+.neon-border {
+  border: 2px solid transparent;
+  border-image: linear-gradient(90deg, var(--accent), var(--accent-2)) 1;
+  box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 30%, transparent);
+  transition: box-shadow .3s ease;
+}
+
+.neon-border:hover {
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    box-shadow: 0 0 12px color-mix(in srgb, var(--accent) 30%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 20px color-mix(in srgb, var(--accent-2) 40%, transparent);
+  }
+}
+
 .section-title {
   margin: 0 0 16px;
 }

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -5,7 +5,7 @@
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit">Записаться</button>
+    <button type="submit" class="btn neon-border">Записаться</button>
     <p class="application-price">
       <span class="price-old">
         {{ application_price.original }} ₽/мес

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -62,7 +62,7 @@
             </span>
           </p>
         </div>
-        <button type="submit" class="btn accent">{% trans "Записаться" %}</button>
+        <button type="submit" class="btn accent neon-border">{% trans "Записаться" %}</button>
       </form>
     </div>
   </div>

--- a/templates/partials/cta.html
+++ b/templates/partials/cta.html
@@ -3,6 +3,6 @@
   <div class="container">
       <h3 class="mt-0 mb-8">{% trans "Готовы начать?" %}</h3>
       <p class="muted mt-0 mb-16">{% trans "Оставьте заявку — подберём программу и формат под ваши цели." %}</p>
-      <a class="btn" href="#">{% trans "Записаться" %}</a>
+      <a class="btn neon-border" href="#">{% trans "Записаться" %}</a>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- add reusable `neon-border` class with gradient frame and pulse animation
- style sign-up buttons with neon effect while restoring default styling on main content blocks

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c055dd35c4832db049d60c6d408204