### PR TITLE
Style about section headings

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -127,6 +127,25 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .signup-form input, .signup-form select, .signup-form textarea { width:100%; padding:var(--space-sm); border:1px solid var(--border); border-radius:8px; background:var(--bg); color:var(--text); }
 .signup-form textarea { height:44px; resize:vertical; }
 
+.subjects-title {
+  font-size: clamp(24px, 5vw, 40px);
+  font-weight: 700;
+  text-align: center;
+  color: var(--accent);
+  margin: 0 0 var(--space-md);
+}
+
+.signup-prompt {
+  font-size: clamp(18px, 4vw, 24px);
+  font-weight: 600;
+  text-align: center;
+  margin: 0 0 var(--space-lg);
+}
+
+@media (max-width: 480px) {
+  .subjects-title { font-size: 24px; }
+  .signup-prompt { font-size: 18px; }
+}
 
 /* Dashboard */
 .dashboard-container { display:flex; gap:2rem; }

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -3,8 +3,8 @@
   <div class="container">
     <div class="block block--futuristic">
       <h3 class="section-title">{% trans "Запись" %}</h3>
-      <p class="muted mb-8">{% trans "ФИЗИКА | МАТЕМАТИКА | ИНФОРМАТИКА | ВПР | ОГЭ | ЕГЭ" %}</p>
-      <p class="mb-8">{% blocktrans trimmed %}Запишитесь через Telegram <a href="https://t.me/Shydoe" target="_blank">@Shydoe</a> или заполните заявку ниже 👇{% endblocktrans %}</p>
+      <h2 class="subjects-title">{% trans "ФИЗИКА | МАТЕМАТИКА | ИНФОРМАТИКА | ВПР | ОГЭ | ЕГЭ" %}</h2>
+      <h3 class="signup-prompt">{% blocktrans trimmed %}Запишитесь через Telegram <a href="https://t.me/Shydoe" target="_blank">@Shydoe</a> или заполните заявку ниже 👇{% endblocktrans %}</h3>
       <form action="{% url 'applications:apply' %}" method="post" class="signup-form">
         {% csrf_token %}
         {{ form.non_field_errors }}


### PR DESCRIPTION
## Summary
- Replace about section paragraphs with semantic h2/h3 headings
- Add `.subjects-title` and `.signup-prompt` styles with centered, bold, responsive typography

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c05dcc003c832da57dbcb5b4a06aa3