### PR TITLE
Add large button style for signup form

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -54,6 +54,7 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 }
 .btn { display: inline-flex; align-items: center; gap: 8px; padding: 10px 16px; background: var(--accent); color: #001420; border-radius: 10px; border: 1px solid color-mix(in srgb, var(--accent) 70%, black); font-weight: 600; cursor: pointer; transition: transform .08s ease, box-shadow .2s ease; }
 .btn:hover { transform: translateY(-1px); box-shadow: 0 6px 20px color-mix(in srgb, var(--accent) 35%, transparent); }
+.btn-large { padding: 14px 24px; font-size: var(--font-lg); border-radius: 14px; justify-content: center; }
 
 /* Hero */
 .hero { padding: 56px 0 28px; border-bottom: 1px solid var(--border); background: radial-gradient(1200px 600px at 70% -100px, color-mix(in srgb, var(--accent) 20%, transparent), transparent); }

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -62,7 +62,7 @@
             </span>
           </p>
         </div>
-        <button type="submit" class="btn accent">{% trans "Записаться" %}</button>
+        <button type="submit" class="btn btn-large accent">{% trans "Записаться" %}</button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- enlarge about page signup button with `btn-large`
- add `.btn-large` style for increased padding and font size

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c05ee16bc0832da18f421646b524dd