### PR TITLE
feat: update sections and testimonials

### DIFF
--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -150,7 +150,7 @@ msgid ""
 msgstr ""
 
 #: templates/home.html:12
-msgid "Запись"
+msgid "Записаться на занятия"
 msgstr ""
 
 #: templates/home.html:41
@@ -162,7 +162,7 @@ msgid "Записаться"
 msgstr ""
 
 #: templates/home.html:51
-msgid "О школе «Фрактал»"
+msgid "О нас"
 msgstr ""
 
 #: templates/home.html:54

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -220,6 +220,10 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
   margin: 0 0 var(--space-lg);
 }
 
+.signup-prompt a {
+  color: var(--accent);
+}
+
 @media (max-width: 480px) {
   .subjects-title { font-size: 18px; }
   .signup-prompt { font-size: 18px; }

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -2,7 +2,7 @@
 <section id="about" class="section">
   <div class="container">
     <div class="block block--futuristic">
-      <h3 class="section-title">{% trans "Запись" %}</h3>
+      <h3 class="section-title">{% trans "Записаться на занятия" %}</h3>
       <h2 class="subjects-title">{% trans "ФИЗИКА | МАТЕМАТИКА | ИНФОРМАТИКА | ВПР | ОГЭ | ЕГЭ" %}</h2>
       <h3 class="signup-prompt">{% blocktrans trimmed %}Запишитесь через Telegram <a href="https://t.me/Shydoe" target="_blank">@Shydoe</a> или заполните заявку ниже 👇{% endblocktrans %}</h3>
       <form action="{% url 'applications:apply' %}" method="post" class="signup-form">

--- a/templates/partials/teachers.html
+++ b/templates/partials/teachers.html
@@ -2,7 +2,7 @@
 <section id="grades" class="section">
   <div class="container">
     <div class="block block--futuristic">
-      <h3 class="section-title">{% trans "О школе «Фрактал»" %}</h3>
+      <h3 class="section-title">{% trans "О нас" %}</h3>
       <p class="muted">{% blocktrans trimmed %}Школа «Фрактал» — семейный проект репетиторов, сочетающий опыт преподавания и технологии 2025 года.{% endblocktrans %}</p>
 
       <div class="subjects mt-12">

--- a/templates/partials/testimonials.html
+++ b/templates/partials/testimonials.html
@@ -4,9 +4,21 @@
     <div class="block block--futuristic reviews-block">
         <h3 class="section-title">{% trans "Отзывы" %}</h3>
       <div class="testimonials">
-          <div class="quote">{% blocktrans trimmed %}«Виктор, спасибо Вам огромное!!! Я вообще в шоке!!! Я Вам бесконечно благодарен!!!».<br><strong>— Дмитрий, 100 баллов на ЕГЭ по информатике</strong>{% endblocktrans %}</div>
-          <div class="quote">{% blocktrans trimmed %}«Было относительно просто, если честно. Вполне себе мог получить 100 баллов, но у меня 99. Тоже неплохо, думаю».<br><strong>— Матвей, 99 баллов на ЕГЭ по математике</strong>{% endblocktrans %}</div>
-          <div class="quote">{% blocktrans trimmed %}«Сдал ЕГЭ на высочайший балл, после чего знаний хватило на то, чтобы самостоятельно подготовиться к ДВИ МГУ по физике на 90+».<br><strong>— Андрей, 97 баллов на ЕГЭ по физике</strong>{% endblocktrans %}</div>
+          <div class="quote">
+            {% blocktrans trimmed %}"Виктор, спасибо Вам огромное!!! Я вообще в шоке!!! Я Вам бесконечно благодарен!!!"{% endblocktrans %}
+            <br>
+            <strong>— Дмитрий, 100 баллов на ЕГЭ по информатике</strong>
+          </div>
+          <div class="quote">
+            {% blocktrans trimmed %}"Было относительно просто, если честно. Вполне себе мог получить 100 баллов, но у меня 99. Тоже неплохо, думаю"{% endblocktrans %}
+            <br>
+            <strong>— Матвей, 99 баллов на ЕГЭ по математике</strong>
+          </div>
+          <div class="quote">
+            {% blocktrans trimmed %}"Сдал ЕГЭ на высочайший балл, после чего знаний хватило на то, чтобы самостоятельно подготовиться к ДВИ МГУ по физике на 90+"{% endblocktrans %}
+            <br>
+            <strong>— Андрей, 97 баллов на ЕГЭ по физике</strong>
+          </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- rename sign-up section to "Записаться на занятия" and about block to "О нас"
- color the @Shydoe link for visibility
- reformat testimonials with standard quotes and line breaks

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c072fcca90832d90fe4de46b31d373