### PR TITLE
Update application submission button and confirmation message

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 from django.urls import reverse_lazy
 from django.views.generic import FormView
+from django.contrib import messages
 
 from .forms import ApplicationForm
 from subjects.models import Subject
@@ -29,6 +30,7 @@ class ApplicationCreateView(FormView):
 
     def form_valid(self, form: ApplicationForm) -> Any:  # type: ignore[override]
         form.save()
+        messages.success(self.request, "Ваша заявка отправлена")
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:  # type: ignore[override]

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -5,7 +5,7 @@
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit">Записаться</button>
+    <button type="submit">Отправить заявку</button>
     <p class="application-price">
       <span class="price-old">
         {{ application_price.original }} ₽/мес

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,6 +32,15 @@
       </div>
     </div>
   </header>
+  {% if messages %}
+  <div class="container">
+    <ul class="messages">
+      {% for message in messages %}
+      <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
   <main>
     {% block content %}{% endblock %}
   </main>

--- a/templates/partials/about.html
+++ b/templates/partials/about.html
@@ -62,7 +62,7 @@
             </span>
           </p>
         </div>
-        <button type="submit" class="btn btn-large accent">{% trans "Записаться" %}</button>
+        <button type="submit" class="btn btn-large accent">{% trans "Отправить заявку" %}</button>
       </form>
     </div>
   </div>

--- a/templates/partials/cta.html
+++ b/templates/partials/cta.html
@@ -3,6 +3,6 @@
   <div class="container">
       <h3 class="mt-0 mb-8">{% trans "Готовы начать?" %}</h3>
       <p class="muted mt-0 mb-16">{% trans "Оставьте заявку — подберём программу и формат под ваши цели." %}</p>
-      <a class="btn" href="#">{% trans "Записаться" %}</a>
+      <a class="btn" href="#">{% trans "Отправить заявку" %}</a>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Rename 'Записаться' buttons to 'Отправить заявку'
- Show a success message after submitting an application

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c077ee0de8832db4e403cff5f49a6c