### PR TITLE
Capture source offer on application forms

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -23,6 +23,7 @@ class ApplicationForm(forms.ModelForm):
         required=False,
         label="",
     )
+    source_offer = forms.CharField(required=False, widget=forms.HiddenInput())
 
 
     class Meta:
@@ -31,6 +32,7 @@ class ApplicationForm(forms.ModelForm):
             "grade",
             "subject1",
             "subject2",
+            "source_offer",
             "contact_info",
             "contact_name",
         ]
@@ -49,6 +51,7 @@ class ApplicationForm(forms.ModelForm):
 
     def save(self, commit: bool = True) -> Application:  # type: ignore[override]
         application = super().save(commit=False)
+        application.source_offer = self.cleaned_data.get("source_offer")
         if commit:
             application.save()
             subjects = []

--- a/applications/tests.py
+++ b/applications/tests.py
@@ -30,6 +30,7 @@ class ApplicationTests(TestCase):
         app = Application.objects.first()
         assert app is not None
         self.assertEqual(app.subjects.count(), 2)
+        self.assertEqual(app.source_offer, "math-9")
 
     def test_application_form_submission_without_grade_or_subjects(self) -> None:
         data = {

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -4,6 +4,7 @@
   <h1>Заявка на обучение</h1>
   <form method="post">
     {% csrf_token %}
+    <input type="hidden" name="source_offer" value="{{ form.initial.source_offer }}">
     {{ form.as_p }}
     <button type="submit">Отправить заявку</button>
     <p class="application-price">


### PR DESCRIPTION
## Summary
- track application source via hidden `source_offer` field
- save `source_offer` on application creation
- test that `source_offer` value persists on submit

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c11676c788832d875a80e1f7b271f0