### PR TITLE
Gracefully handle missing message middleware

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -2,6 +2,7 @@ from typing import Any, Dict
 from django.urls import reverse_lazy
 from django.views.generic import FormView
 from django.contrib import messages
+from django.contrib.messages.api import MessageFailure
 
 from .forms import ApplicationForm
 from subjects.models import Subject
@@ -30,7 +31,10 @@ class ApplicationCreateView(FormView):
 
     def form_valid(self, form: ApplicationForm) -> Any:  # type: ignore[override]
         form.save()
-        messages.success(self.request, "Ваша заявка отправлена")
+        try:
+            messages.success(self.request, "Ваша заявка отправлена")
+        except MessageFailure:
+            pass
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:  # type: ignore[override]


### PR DESCRIPTION
## Summary
- avoid crashing if message middleware is absent by catching MessageFailure in ApplicationCreateView

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c159cc1e1c832da3ea302d6ea2ebaa