### PR TITLE
Add AJAX form submission for applications

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 from django.urls import reverse_lazy
 from django.views.generic import FormView
 from django.contrib import messages
-from django.contrib.messages.api import MessageFailure
+from django.http import JsonResponse
 
 from .forms import ApplicationForm
 from subjects.models import Subject
@@ -31,10 +31,9 @@ class ApplicationCreateView(FormView):
 
     def form_valid(self, form: ApplicationForm) -> Any:  # type: ignore[override]
         form.save()
-        try:
-            messages.success(self.request, "Ваша заявка отправлена")
-        except MessageFailure:
-            pass
+        if self.request.headers.get("X-Requested-With") == "XMLHttpRequest":
+            return JsonResponse({"message": "Ваша заявка отправлена"})
+        messages.success(self.request, "Ваша заявка отправлена")
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:  # type: ignore[override]

--- a/templates/applications/application_form.html
+++ b/templates/applications/application_form.html
@@ -7,6 +7,7 @@
     <input type="hidden" name="source_offer" value="{{ form.initial.source_offer }}">
     {{ form.as_p }}
     <button type="submit">Отправить заявку</button>
+    <div id="form-message"></div>
     <p class="application-price">
       <span class="price-old">
         {{ application_price.original }} ₽/мес
@@ -22,4 +23,23 @@
       </span>
     </p>
   </form>
+  <script>
+    document.querySelector('form').addEventListener('submit', async e => {
+        e.preventDefault();
+        const form = e.target;
+        const msg = document.getElementById('form-message');
+        const resp = await fetch(form.action || window.location.href, {
+            method: 'POST',
+            headers: {'X-Requested-With': 'XMLHttpRequest'},
+            body: new FormData(form),
+        });
+        if (resp.ok) {
+            const data = await resp.json();
+            msg.textContent = data.message;
+            form.reset();
+        } else {
+            msg.textContent = 'Не удалось отправить.';
+        }
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Display submission message and handle application form via AJAX
- Return JSON message for AJAX requests in application view

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c1b6836e8c832d9b4f4793f6831d99