### PR TITLE
Add PyMySQL dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ whitenoise
 dj-database-url
 psycopg2-binary
 djangorestframework
+pymysql


### PR DESCRIPTION
## Summary
- include PyMySQL in requirements
- ensure Dockerfile installs dependencies

## Testing
- `python manage.py collectstatic --noinput`
- `docker build -t django-site-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68c4400acb04832d8cf5036d8aa9fc74