### PR TITLE
Use DATABASE_URL for database configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ SECRET_KEY=changeme
 DEBUG=False
 # ALLOWED_HOSTS is optional, comma-separated list
 # ALLOWED_HOSTS=example.com,localhost
+# CSRF_TRUSTED_ORIGINS is optional, comma-separated list of origins
+# CSRF_TRUSTED_ORIGINS=https://example.com,https://www.example.com
+# Database connection URL
+# DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DBNAME

--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 ## Установка и запуск
 
-Для запуска сервера выполните следующие команды:
+Создайте файл `.env` и укажите переменные окружения:
+
+```bash
+SECRET_KEY=changeme
+DEBUG=True
+ALLOWED_HOSTS=localhost
+CSRF_TRUSTED_ORIGINS=http://localhost
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DBNAME
+```
+
+Затем выполните миграции и запустите сервер:
 
 ```bash
 python manage.py migrate

--- a/fractalschool/settings.py
+++ b/fractalschool/settings.py
@@ -12,9 +12,8 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 import os
 from pathlib import Path
-import pymysql
-pymysql.install_as_MySQLdb()
 from dotenv import load_dotenv
+import dj_database_url
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -37,7 +36,8 @@ DEBUG = os.environ.get("DEBUG", "False") == "True"
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "")
 ALLOWED_HOSTS = ALLOWED_HOSTS.split(",") if ALLOWED_HOSTS else []
 
-CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS", "").split(",")
+CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS", "")
+CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS.split(",") if CSRF_TRUSTED_ORIGINS else []
 
 
 # Application definition
@@ -94,14 +94,10 @@ WSGI_APPLICATION = 'fractalschool.wsgi.application'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': os.environ.get('DB_NAME'),
-        'USER': os.environ.get('DB_USER'),
-        'PASSWORD': os.environ.get('DB_PASSWORD'),
-        'HOST': os.environ.get('DB_HOST', 'localhost'), # 'localhost' как значение по умолчанию
-        'PORT': '3306',
-    }
+    "default": dj_database_url.config(
+        default=os.environ.get("DATABASE_URL"),
+        conn_max_age=600,
+    )
 }
 
 # Password validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ whitenoise
 dj-database-url
 psycopg2-binary
 djangorestframework
-pymysql
+python-dotenv


### PR DESCRIPTION
## Summary
- configure database via dj-database-url and DATABASE_URL
- document required environment variables
- drop MySQL dependencies and add python-dotenv

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68c442ca5080832db6ae72a03b561994