### PR TITLE
Use absolute static URL

### DIFF
--- a/fractalschool/settings.py
+++ b/fractalschool/settings.py
@@ -85,7 +85,7 @@ USE_I18N = True
 USE_TZ = True
 LOCALE_PATHS = [BASE_DIR / "locale"]
 
-STATIC_URL = "static/"
+STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "public" / "static"
 STATICFILES_DIRS = [BASE_DIR / "static"]
 


### PR DESCRIPTION
## Summary
- point STATIC_URL to an absolute `/static/` path to correctly serve static assets

## Testing
- `python manage.py collectstatic --noinput`
- `DEBUG=True python manage.py runserver 0:8000` (logged and terminated)
- `pytest -q` *(fails: AppRegistryNotReady)*

------
https://chatgpt.com/codex/tasks/task_e_68c586689488832dbb6ecb8acd10d181