### PR TITLE
Configure WhiteNoise static file handling

### DIFF
--- a/fractalschool/settings.py
+++ b/fractalschool/settings.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -88,6 +89,7 @@ LOCALE_PATHS = [BASE_DIR / "locale"]
 STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "public" / "static"
 STATICFILES_DIRS = [BASE_DIR / "static"]
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 LOGIN_REDIRECT_URL = "/"


### PR DESCRIPTION
## Summary
- add WhiteNoise middleware
- configure static files to use WhiteNoise's compressed manifest storage

## Testing
- `python manage.py collectstatic --noinput`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c58762e0e0832da582da4bc88ffd7a