### PR TITLE
Ensure static files collected during deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ staticfiles/
 media/
 .venv/
 passenger_wsgi.py
+public/
+

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: python manage.py collectstatic --noinput
 web: gunicorn fractalschool.wsgi

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DBNAME
 python manage.py migrate
 python manage.py createsuperuser
 python manage.py seed_ege
+python manage.py collectstatic --noinput
 python manage.py runserver
 ```
 

--- a/gunicorn.service
+++ b/gunicorn.service
@@ -7,6 +7,7 @@ User=www-data
 Group=www-data
 WorkingDirectory=/path/to/app
 Environment="PATH=/path/to/venv/bin"
+ExecStartPre=/path/to/venv/bin/python manage.py collectstatic --noinput
 ExecStart=/path/to/venv/bin/gunicorn fractalschool.wsgi:application --bind 0.0.0.0:8000
 
 [Install]


### PR DESCRIPTION
## Summary
- run `collectstatic` automatically in deployment scripts (`Procfile`, `gunicorn.service`)
- document `collectstatic` in setup instructions
- ignore generated `public/` static directory

## Testing
- `python manage.py test`
- `python manage.py collectstatic --noinput`


------
https://chatgpt.com/codex/tasks/task_e_68c58a1b2c08832d815fecb9dce31c44