### PR TITLE
Show selected exams in dashboard settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.sqlite3
 *.log
 *.pot
+*.mo
 *.py[cod]
 *.egg-info/
 .env

--- a/accounts/templates/accounts/dashboard/settings.html
+++ b/accounts/templates/accounts/dashboard/settings.html
@@ -28,6 +28,16 @@
       <p class="hint">{% trans "Нет доступных предметов" %}</p>
     {% endfor %}
   </div>
+  <h3 class="mb-8">{% trans "Ваши экзамены" %}</h3>
+  {% if selected_exams %}
+    <ul class="mb-16">
+      {% for exam in selected_exams %}
+        <li>{{ exam.subject.name }} — {{ exam.name }}</li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p class="hint mb-16">{% trans "Вы ещё не выбрали экзамены" %}</p>
+  {% endif %}
   <div class="flex items-center gap-8">
     <button type="submit" name="exams_submit" class="btn" id="exams-submit">{% trans "Сохранить выбор" %}</button>
     <span id="exams-saving" class="hint" style="display:none">{% trans "Сохраняем выбор..." %}</span>

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -75,4 +75,7 @@ class DashboardSettingsTests(TestCase):
             f'value="{exam_second.id}" checked="checked"',
             html=False,
         )
+        self.assertContains(response, "Ваши экзамены")
+        self.assertContains(response, "Математика — Пробный вариант 1")
+        self.assertContains(response, "Математика — Пробный вариант 2")
         self.assertNotContains(response, "выбрать экзамены можно")

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -149,12 +149,18 @@ def dashboard_settings(request):
         p_form = PasswordChangeForm(request.user)
         exams_form = ExamPreferencesForm(instance=profile)
 
+    selected_exams = (
+        profile.exam_versions.select_related("subject")
+        .order_by("subject__name", "name")
+    )
+
     context = {
         "u_form": u_form,
         "p_form": p_form,
         "exams_form": exams_form,
         "subjects": subjects_qs,
         "selected_exam_ids": _get_selected_exam_ids(profile, exams_form),
+        "selected_exams": selected_exams,
         "active_tab": "settings",
         "role": role,
     }

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-06 17:47+0000\n"
+"POT-Creation-Date: 2025-09-18 13:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,106 +19,169 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
 "(n%100>=11 && n%100<=14)? 2 : 3);\n"
-#: accounts/forms.py:14
+
+#: accounts/forms.py:16
 msgid "Контактные данные"
 msgstr ""
 
-#: accounts/forms.py:17
+#: accounts/forms.py:19
 msgid ""
 "Укажите email или телефон — они понадобятся в случае восстановления аккаунта"
 msgstr ""
 
-#: accounts/forms.py:20 accounts/forms.py:60
+#: accounts/forms.py:22 accounts/forms.py:62
 msgid "Логин"
 msgstr ""
 
-#: accounts/forms.py:21
+#: accounts/forms.py:23
 msgid "Пароль"
 msgstr ""
 
-#: accounts/forms.py:26 accounts/forms.py:49 accounts/forms.py:78
+#: accounts/forms.py:28 accounts/forms.py:51 accounts/forms.py:80
 msgid "Этот логин уже занят"
 msgstr ""
 
-#: accounts/forms.py:61
+#: accounts/forms.py:63
 msgid "Имя"
 msgstr ""
 
-#: accounts/forms.py:62
+#: accounts/forms.py:64
 msgid "Фамилия"
 msgstr ""
 
-#: accounts/forms.py:63
+#: accounts/forms.py:65
 msgid "Электронная почта"
 msgstr ""
 
-#: accounts/forms.py:66
+#: accounts/forms.py:68
 msgid "Укажите логин"
 msgstr ""
 
-#: accounts/forms.py:67
+#: accounts/forms.py:69
 msgid "Укажите имя"
 msgstr ""
 
-#: accounts/forms.py:68
+#: accounts/forms.py:70
 msgid "Укажите фамилию"
 msgstr ""
 
-#: accounts/forms.py:70
+#: accounts/forms.py:72
 msgid "Укажите адрес электронной почты"
 msgstr ""
 
-#: accounts/forms.py:71
+#: accounts/forms.py:73
 msgid "Введите правильный адрес электронной почты"
 msgstr ""
 
-#: accounts/forms.py:87
+#: accounts/forms.py:89
 msgid "Старый пароль"
 msgstr ""
 
-#: accounts/forms.py:88
+#: accounts/forms.py:90
 msgid "Новый пароль"
 msgstr ""
 
-#: accounts/forms.py:89
+#: accounts/forms.py:91
 msgid "Подтверждение нового пароля"
 msgstr ""
 
+#: accounts/forms_exams.py:12
+#: accounts/templates/accounts/dashboard/settings.html:31
+msgid "Ваши экзамены"
+msgstr "Ваши экзамены"
+
+#: accounts/templates/accounts/dashboard/base.html:10
+msgid "Экзамены пользователя"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/base.html:16
+msgid "выбрать экзамены можно в"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/base.html:16
+msgid "настройках"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/base.html:21
+msgid "Навигация по разделам"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/base.html:24
+msgid "Задания"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/base.html:27
+msgid "Предметы"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/base.html:30
+msgid "Курсы"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/base.html:33
 #: accounts/templates/accounts/dashboard/settings.html:4
-#: accounts/templates/accounts/dashboard/settings.html:7
+#: accounts/templates/accounts/dashboard/settings.html:47
 msgid "Настройки"
 msgstr ""
 
-#: accounts/templates/accounts/dashboard/settings.html:11
-msgid "Режим кабинета"
-msgstr ""
-
-#: accounts/templates/accounts/dashboard/settings.html:14
-msgid "Ученик"
-msgstr ""
-
-#: accounts/templates/accounts/dashboard/settings.html:16
-msgid "Учитель"
-msgstr ""
-
-#: accounts/templates/accounts/dashboard/settings.html:18
-msgid "Сменить режим"
+#: accounts/templates/accounts/dashboard/settings.html:9
+msgid "Выбор экзаменов"
 msgstr ""
 
 #: accounts/templates/accounts/dashboard/settings.html:23
-msgid "Личная информация"
+msgid "Нет доступных экзаменов для этого предмета"
 msgstr ""
 
-#: accounts/templates/accounts/dashboard/settings.html:34
-msgid "Сохранить изменения"
+#: accounts/templates/accounts/dashboard/settings.html:28
+msgid "Нет доступных предметов"
 msgstr ""
 
-#: accounts/templates/accounts/dashboard/settings.html:38
-#: accounts/templates/accounts/dashboard/settings.html:49
-msgid "Изменить пароль"
+#: accounts/templates/accounts/dashboard/settings.html:39
+msgid "Вы ещё не выбрали экзамены"
+msgstr "Вы ещё не выбрали экзамены"
+
+#: accounts/templates/accounts/dashboard/settings.html:42
+msgid "Сохранить выбор"
 msgstr ""
 
-#: accounts/templates/accounts/dashboard/settings.html:53
+#: accounts/templates/accounts/dashboard/settings.html:43
+#: accounts/templates/accounts/dashboard/settings.html:106
+msgid "Сохраняем выбор..."
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/settings.html:51
+msgid "Роль в кабинете"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/settings.html:54
+msgid "Студент"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/settings.html:56
+msgid "Преподаватель"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/settings.html:58
+msgid "Сохранить роль"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/settings.html:64
+msgid "Личные данные"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/settings.html:75
+msgid "Сохранить данные"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/settings.html:80
+msgid "Смена пароля"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/settings.html:91
+msgid "Сменить пароль"
+msgstr ""
+
+#: accounts/templates/accounts/dashboard/settings.html:96
 msgid "Выйти из аккаунта"
 msgstr ""
 
@@ -135,142 +198,141 @@ msgstr ""
 msgid "Войти"
 msgstr ""
 
+#: accounts/views.py:136
+msgid "Выбор сохранён"
+msgstr ""
+
+#: applications/forms.py:45
+msgid "Ваши контакты и комментарий"
+msgstr ""
+
+#: applications/forms.py:48
+msgid "Ваше имя"
+msgstr ""
+
 #: templates/home.html:4
 msgid "Fractal School — главная"
 msgstr ""
 
-#: templates/home.html:10
-msgid "ФИЗИКА | МАТЕМАТИКА | ИНФОРМАТИКА | ВПР | ОГЭ | ЕГЭ"
-msgstr ""
-
-#: templates/home.html:11
-msgid ""
-"Запишитесь через Telegram <a href=\"https://t.me/Shydoe\" "
-"target=\"_blank\">@Shydoe</a> или заполните заявку ниже 👇"
-msgstr ""
-
-#: templates/home.html:12
-msgid "Записаться на занятия"
-msgstr ""
-
-#: templates/home.html:41
-msgid "Цена: ..."
-msgstr ""
-
-#: templates/home.html:42 templates/home.html:104
-msgid "Записаться"
-msgstr ""
-
-#: templates/home.html:51
+#: templates/partials/aboutus.html:1
 msgid "О нас"
 msgstr ""
 
-#: templates/home.html:54
+#: templates/partials/aboutus.html:1
 msgid ""
 "Школа «Фрактал» — семейный проект репетиторов, сочетающий опыт преподавания "
 "и технологии 2025 года."
 msgstr ""
 
-#: templates/home.html:58
+#: templates/partials/aboutus.html:1
 msgid "Ермаков Вадим Александрович"
 msgstr ""
 
-#: templates/home.html:59
+#: templates/partials/aboutus.html:1
 msgid ""
 "МГТУ им. Баумана (1985), инженер. Учитель и репетитор с 40-летним стажем."
 msgstr ""
 
-#: templates/home.html:62
+#: templates/partials/aboutus.html:1
 msgid "Ермаков Виктор Вадимович"
 msgstr ""
 
-#: templates/home.html:63
+#: templates/partials/aboutus.html:1
 msgid ""
 "МГТУ им. Баумана (2013), инженер; МГТУ СТАНКИН (2025), программист машинного "
 "обучения. Репетитор с 15-летним стажем."
 msgstr ""
 
-#: templates/home.html:66
+#: templates/partials/aboutus.html:1
 msgid "Ермакова Мария Вадимовна"
 msgstr ""
 
-#: templates/home.html:67
+#: templates/partials/aboutus.html:1
 msgid ""
 "МГОУ (2018), физик; РУДН (2020), инженер. Школьный учитель и репетитор с 10-"
 "летним стажем."
 msgstr ""
 
-#: templates/home.html:72
+#: templates/partials/aboutus.html:1
 msgid "Наша система обучения"
 msgstr ""
 
-#: templates/home.html:73
+#: templates/partials/aboutus.html:1
 msgid ""
 "С 2024 года мы строим процесс обучения, который использует всю мощь "
 "современных технологий. С сентября 2025 представляем новую образовательную "
 "систему:"
 msgstr ""
 
-#: templates/home.html:75
+#: templates/partials/aboutus.html:1
 msgid ""
 "<strong>Уникальные задачи:</strong> задания генерируются автоматически по "
 "правилам. У каждого ученика — свои условия (их нет в интернете и у других "
 "учеников), при строгом соответствии кодификаторам ФИПИ."
 msgstr ""
 
-#: templates/home.html:76
+#: templates/partials/aboutus.html:1
 msgid ""
 "<strong>Умный уровень нагрузки:</strong> сложность и объём домашки "
 "подбираются алгоритмами в зависимости от прогресса."
 msgstr ""
 
-#: templates/home.html:77
+#: templates/partials/aboutus.html:1
 msgid ""
 "<strong>Геймификация прогресса:</strong> достижения оформлены как "
 "увлекательная игра, поддерживающая фокус и мотивацию."
 msgstr ""
 
-#: templates/home.html:78
+#: templates/partials/aboutus.html:1
 msgid ""
 "<strong>Нейропомощник:</strong> для быстрых вопросов — ассистент на базе "
 "нейросетей, настроенный на учебную программу РФ."
 msgstr ""
 
-#: templates/home.html:80
+#: templates/partials/aboutus.html:1
 msgid ""
 "<strong>И главное:</strong> в основе остаются занятия с живым преподавателем "
 "— гарантия качества и уверенности на экзамене!"
 msgstr ""
 
-#: templates/home.html:90
-msgid "Отзывы"
-msgstr ""
-
-#: templates/home.html:92
-msgid ""
-"«Виктор, спасибо Вам огромное!!! Я вообще в шоке!!! Я Вам бесконечно "
-"благодарен!!!».<br><strong>— Дмитрий, 100 баллов на ЕГЭ по информатике</"
-"strong>"
-msgstr ""
-
-#: templates/home.html:93
-msgid ""
-"«Было относительно просто, если честно. Вполне себе мог получить 100 баллов, "
-"но у меня 99. Тоже неплохо, думаю».<br><strong>— Матвей, 99 баллов на ЕГЭ по "
-"математике</strong>"
-msgstr ""
-
-#: templates/home.html:94
-msgid ""
-"«Сдал ЕГЭ на высочайший балл, после чего знаний хватило на то, чтобы "
-"самостоятельно подготовиться к ДВИ МГУ по физике на 90+».<br><strong>— "
-"Андрей, 97 баллов на ЕГЭ по физике</strong>"
-msgstr ""
-
-#: templates/home.html:102
+#: templates/partials/cta.html:4
 msgid "Готовы начать?"
 msgstr ""
 
-#: templates/home.html:103
+#: templates/partials/cta.html:5
 msgid "Оставьте заявку — подберём программу и формат под ваши цели."
+msgstr ""
+
+#: templates/partials/cta.html:6 templates/partials/enroll.html:65
+msgid "Отправить заявку"
+msgstr ""
+
+#: templates/partials/enroll.html:5
+msgid "Записаться на занятия"
+msgstr ""
+
+#: templates/partials/enroll.html:6
+msgid "ФИЗИКА | МАТЕМАТИКА | ИНФОРМАТИКА | ВПР | ОГЭ | ЕГЭ"
+msgstr ""
+
+#: templates/partials/enroll.html:7
+msgid ""
+"Запишитесь через Telegram <a href=\"https://t.me/Shydoe\" "
+"target=\"_blank\">@Shydoe</a> или заполните заявку ниже 👇"
+msgstr ""
+
+#: templates/partials/enroll.html:15
+msgid "выберите класс"
+msgstr ""
+
+#: templates/partials/enroll.html:24
+msgid "выберите предмет"
+msgstr ""
+
+#: templates/partials/enroll.html:33
+msgid "выберите второй предмет"
+msgstr ""
+
+#: templates/partials/enroll.html:37
+msgid "- не нужен -"
 msgstr ""


### PR DESCRIPTION
## Summary
- expose the student's selected exam versions in the dashboard settings context
- render the selected exams list with a localized empty state in the settings template
- update Russian translations and extend dashboard settings tests to cover the new list
- stop tracking compiled locale binaries by deleting the generated `django.mo` and ignoring future `.mo` artifacts

## Testing
- python manage.py test accounts.tests.DashboardSettingsTests

------
https://chatgpt.com/codex/tasks/task_e_68cc056e6d08832da466b23f87340c7c