### PR TITLE
Add debug logging for dashboard exam selections

### DIFF
--- a/accounts/templates/accounts/dashboard/settings.html
+++ b/accounts/templates/accounts/dashboard/settings.html
@@ -7,6 +7,20 @@
 <form method="post" class="card mb-16" id="exams-form">
   {% csrf_token %}
   <h2 class="mb-8">{% trans "Выбор экзаменов" %}</h2>
+  <div class="block block--futuristic mb-16" style="padding: 12px;">
+    <strong>{% trans "Отладочный вывод:" %}</strong>
+    <div style="margin-top: 8px;">
+      <div><code>selected_exam_ids</code>: {{ selected_exam_ids|join:", " }}</div>
+      <div><code>selected_exams</code>:</div>
+      <ul class="hint" style="margin-top: 4px;">
+        {% for exam in selected_exams %}
+          <li>#{{ exam.id }} — {{ exam.subject.name }} — {{ exam.name }}</li>
+        {% empty %}
+          <li>{% trans "(пусто)" %}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
   {{ exams_form.non_field_errors }}
   <pre class="errorlist" style="margin-top:8px; white-space:pre-wrap;">{{ exams_form.errors.as_text }}</pre>
   <div class="mb-16">


### PR DESCRIPTION
## Summary
- add temporary debug logging to trace exam version payloads and profile state when saving settings
- log selected exam data sent to the dashboard settings template for easier troubleshooting
- render the selected exam IDs and records directly under the "Выбор экзаменов" heading for on-page debugging

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cc0cd0b960832d81b179869fc68f6b