### PR TITLE
Configure logging to stdout

### DIFF
--- a/fractalschool/settings.py
+++ b/fractalschool/settings.py
@@ -1,5 +1,6 @@
 # fractalschool/settings.py
 import os
+import sys
 from pathlib import Path
 import dj_database_url
 
@@ -105,4 +106,19 @@ CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"
 
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
+}
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+        }
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": os.environ.get("DJANGO_LOG_LEVEL", "INFO"),
+    },
 }


### PR DESCRIPTION
## Summary
- import sys and configure Django logging to stream to stdout using an environment-controlled log level

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc477a5974832dbd1b8db598154b5c