### PR TITLE
Adjust dashboard settings logging format

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -209,15 +209,13 @@ def dashboard_settings(request):
         db_selected_exam_ids,
     )
     logger.info(
-        "Dashboard settings context",
-        extra={
-            "connection_alias": connection.alias,
-            "profile_id": profile.pk,
-            "user_id": request.user.pk,
-            "selected_exam_ids": selected_exam_ids,
-            "db_selected_exam_ids": db_selected_exam_ids,
-            "through_records": through_records,
-        },
+        "Dashboard settings context: alias=%s profile_id=%s user_id=%s selected_exam_ids=%s db_selected_exam_ids=%s through_records=%s",
+        connection.alias,
+        profile.pk,
+        request.user.pk,
+        selected_exam_ids,
+        db_selected_exam_ids,
+        through_records,
     )
     return render(request, "accounts/dashboard/settings.html", context)
 


### PR DESCRIPTION
## Summary
- replace the dashboard settings info log with a formatted message containing alias, profile, user, and exam selection details
- ensure selected exam ids and through records appear in the log text for easier filtering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc7fecedbc832d8e3ce48a65685e71