### PR TITLE
Remove exams list from dashboard settings

### DIFF
--- a/accounts/templates/accounts/dashboard/settings.html
+++ b/accounts/templates/accounts/dashboard/settings.html
@@ -28,16 +28,6 @@
       <p class="hint">{% trans "Нет доступных предметов" %}</p>
     {% endfor %}
   </div>
-  <h3 class="mb-8">{% trans "Ваши экзамены" %}</h3>
-  {% if selected_exams %}
-    <ul class="mb-16">
-      {% for exam in selected_exams %}
-        <li>{{ exam.subject.name }} — {{ exam.name }}</li>
-      {% endfor %}
-    </ul>
-  {% else %}
-    <p class="hint mb-16">{% trans "Вы ещё не выбрали экзамены" %}</p>
-  {% endif %}
   <div class="flex items-center gap-8">
     <button type="submit" name="exams_submit" class="btn" id="exams-submit">{% trans "Сохранить выбор" %}</button>
     <span id="exams-saving" class="hint" style="display:none">{% trans "Сохраняем выбор..." %}</span>

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -74,9 +74,9 @@ class DashboardSettingsTests(TestCase):
             f'value="{exam_second.id}" checked="checked"',
             html=False,
         )
-        self.assertContains(response, "Ваши экзамены")
-        self.assertContains(response, "Математика — Пробный вариант 1")
-        self.assertContains(response, "Математика — Пробный вариант 2")
+        self.assertNotContains(response, "Ваши экзамены")
+        self.assertNotContains(response, "Математика — Пробный вариант 1")
+        self.assertNotContains(response, "Математика — Пробный вариант 2")
         self.assertNotContains(response, "выбрать экзамены можно")
 
     def test_exam_selection_submission_without_choices_clears_profile(self):


### PR DESCRIPTION
## Summary
- remove the "Ваши экзамены" heading and selected exams list from the dashboard settings page
- update dashboard settings tests to align with the simplified view

## Testing
- python manage.py test accounts

------
https://chatgpt.com/codex/tasks/task_e_68cc9314c008832db63c6b58f92a9107