### PR TITLE
Rename dashboard subjects tab to statistics

### DIFF
--- a/accounts/templates/accounts/dashboard/base.html
+++ b/accounts/templates/accounts/dashboard/base.html
@@ -23,8 +23,8 @@
       <li class="{% if active_tab == 'tasks' %}active{% endif %}" role="presentation">
         <a role="tab" aria-selected="{% if active_tab == 'tasks' %}true{% else %}false{% endif %}" href="{% url 'accounts:dashboard' %}">{% trans 'Задания' %}</a>
       </li>
-      <li class="{% if active_tab == 'subjects' %}active{% endif %}" role="presentation">
-        <a role="tab" aria-selected="{% if active_tab == 'subjects' %}true{% else %}false{% endif %}" href="{% url 'accounts:dashboard-subjects' %}">{% trans 'Предметы' %}</a>
+      <li class="{% if active_tab == 'statistics' %}active{% endif %}" role="presentation">
+        <a role="tab" aria-selected="{% if active_tab == 'statistics' %}true{% else %}false{% endif %}" href="{% url 'accounts:dashboard-subjects' %}">{% trans 'Статистика' %}</a>
       </li>
       <li class="{% if active_tab == 'courses' %}active{% endif %}" role="presentation">
         <a role="tab" aria-selected="{% if active_tab == 'courses' %}true{% else %}false{% endif %}" href="{% url 'accounts:dashboard-courses' %}">{% trans 'Курсы' %}</a>

--- a/accounts/templates/accounts/dashboard/subjects.html
+++ b/accounts/templates/accounts/dashboard/subjects.html
@@ -1,7 +1,7 @@
 {% extends 'accounts/dashboard/base.html' %}
 {% load progress_extras %}
 
-{% block dashboard_title %}Предметы{% endblock %}
+{% block dashboard_title %}Статистика{% endblock %}
 
 {% block dashboard_content %}
 {% for item in subjects_data %}

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -112,7 +112,7 @@ msgstr ""
 
 #: accounts/templates/accounts/dashboard/base.html:27
 msgid "Предметы"
-msgstr ""
+msgstr "Статистика"
 
 #: accounts/templates/accounts/dashboard/base.html:30
 msgid "Курсы"


### PR DESCRIPTION
## Summary
- rename the dashboard "Subjects" tab and title to "Статистика"
- update the active tab key used for the statistics dashboard view
- adjust the Russian translation entry to render "Статистика"

## Testing
- python manage.py compilemessages

------
https://chatgpt.com/codex/tasks/task_e_68cd1c6382b4832da59a7b13a63b8972