### PR TITLE
Refine subjects dashboard to use selected exams

### DIFF
--- a/accounts/templates/accounts/dashboard/subjects.html
+++ b/accounts/templates/accounts/dashboard/subjects.html
@@ -4,12 +4,12 @@
 {% block dashboard_title %}Статистика{% endblock %}
 
 {% block dashboard_content %}
-{% for item in subjects_data %}
-  {% with subj=item.subject %}
+{% for item in exam_statistics %}
+  {% with subj=item.subject exam=item.exam_version %}
   <section class="section">
     <div class="section-title">
       <span class="dot"></span>
-      <span>{{ subj.name }} — Скиллы{% if item.exam_version %} ({{ item.exam_version.name }}){% endif %}</span>
+      <span>{{ subj.name }} — {{ exam.name }}</span>
     </div>
 
     {% if item.groups %}
@@ -72,6 +72,6 @@
   </section>
   {% endwith %}
 {% empty %}
-  <p>Пока нет предметов для отображения.</p>
+  <p>Пока нет выбранных экзаменов.</p>
 {% endfor %}
 {% endblock %}

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -110,3 +110,30 @@ class DashboardSettingsTests(TestCase):
 
         profile = StudentProfile.objects.get(user=self.user)
         self.assertEqual(list(profile.exam_versions.all()), [exam])
+
+
+class DashboardSubjectsTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="student", password="pass", email="student@example.com"
+        )
+
+    def test_only_selected_exam_is_displayed(self):
+        subject = Subject.objects.create(name="Математика", slug="matematika")
+        selected_exam = ExamVersion.objects.create(
+            subject=subject, name="Вариант 1"
+        )
+        other_exam = ExamVersion.objects.create(subject=subject, name="Вариант 2")
+
+        profile, _ = StudentProfile.objects.get_or_create(user=self.user)
+        profile.exam_versions.set([selected_exam])
+
+        self.client.login(username="student", password="pass")
+
+        response = self.client.get(reverse("accounts:dashboard-subjects"))
+
+        self.assertContains(
+            response,
+            f"{subject.name} — {selected_exam.name}",
+        )
+        self.assertNotContains(response, other_exam.name)


### PR DESCRIPTION
## Summary
- build subjects dashboard data from the student's selected exam versions with related skill groups and task types
- render the subjects dashboard per exam using the new statistics collection and updated empty state messaging
- add a regression test ensuring only selected exams appear on the subjects dashboard

## Testing
- python manage.py test accounts

------
https://chatgpt.com/codex/tasks/task_e_68cd1f2100c4832dbd22c827b57b5495