### PR TITLE
Use skill names in dashboard subjects

### DIFF
--- a/accounts/templates/accounts/dashboard/subjects.html
+++ b/accounts/templates/accounts/dashboard/subjects.html
@@ -22,10 +22,10 @@
               {% with pct=m|default:0|mul:100 %}
               <div class="item">
                 <div class="label">
-                  <span>{{ gi.label }}</span>
+                  <span>{{ gi.skill.name }}</span>
                   <span class="pct">{{ pct|floatformat:0 }}%</span>
                 </div>
-                <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ pct|floatformat:0 }}" aria-label="{{ gi.label }}">
+                <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ pct|floatformat:0 }}" aria-label="{{ gi.skill.name }}">
                   <div class="fill" style="width: {{ pct }}%"></div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- update the subjects dashboard template to render each group's skill name instead of the generic label
- ensure the progress bar accessibility label also references the skill name for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd49faf858832db3102c331990ef75