### PR TITLE
Improve exam dashboard presentation

### DIFF
--- a/accounts/templates/accounts/dashboard/subjects.html
+++ b/accounts/templates/accounts/dashboard/subjects.html
@@ -1,7 +1,130 @@
 {% extends 'accounts/dashboard/base.html' %}
+{% load i18n %}
 
-{% block dashboard_title %}Предметы{% endblock %}
+{% block dashboard_title %}{% trans "Предметы" %}{% endblock %}
 
 {% block dashboard_content %}
-<p>Здесь будут мои предметы.</p>
+  <div class="exam-section">
+    {% if exams %}
+      {% for exam in exams %}
+        <article class="block block--futuristic exam-card">
+          <header class="exam-card__header">
+            <div>
+              <h2 class="exam-card__title">{{ exam.name }}</h2>
+              <p class="exam-card__subtitle">{% blocktrans with subject=exam.subject %}Подготовка по предмету «{{ subject }}»{% endblocktrans %}</p>
+            </div>
+            <div class="exam-card__stats-preview">
+              <span class="exam-card__stat">
+                <span class="exam-card__stat-value">{{ exam.stats.skill_count }}</span>
+                <span class="exam-card__stat-label">{% trans "навыков" %}</span>
+              </span>
+              <span class="exam-card__stat">
+                <span class="exam-card__stat-value">{{ exam.stats.task_type_count }}</span>
+                <span class="exam-card__stat-label">{% trans "типов" %}</span>
+              </span>
+              <span class="exam-card__stat">
+                <span class="exam-card__stat-value">{{ exam.stats.task_count }}</span>
+                <span class="exam-card__stat-label">{% trans "заданий" %}</span>
+              </span>
+            </div>
+          </header>
+
+          <nav class="exam-tabs" role="tablist" aria-label="{% blocktrans %}Навигация по экзамену {{ exam.name }}{% endblocktrans %}">
+            <button
+              type="button"
+              class="exam-tab is-active"
+              data-target="skills-{{ exam.id }}"
+              aria-controls="skills-{{ exam.id }}"
+              aria-selected="true"
+            >{% trans "Навыки" %}</button>
+            <button
+              type="button"
+              class="exam-tab"
+              data-target="types-{{ exam.id }}"
+              aria-controls="types-{{ exam.id }}"
+              aria-selected="false"
+            >{% trans "Типы заданий" %}</button>
+            <button
+              type="button"
+              class="exam-tab"
+              data-target="stats-{{ exam.id }}"
+              aria-controls="stats-{{ exam.id }}"
+              aria-selected="false"
+            >{% trans "Статистика" %}</button>
+          </nav>
+
+          <div class="exam-panels">
+            <section id="skills-{{ exam.id }}" class="exam-panel is-active" role="tabpanel">
+              {% if exam.skill_groups %}
+                <div class="exam-groups">
+                  {% for group in exam.skill_groups %}
+                    <article class="exam-group">
+                      <h3 class="exam-group__title">{{ group.title }}</h3>
+                      {% if group.items %}
+                        <ul class="exam-skill-list">
+                          {% for item in group.items %}
+                            <li class="exam-skill">
+                              <span class="exam-skill__label">{{ item.label }}</span>
+                              <span class="exam-skill__hint">{{ item.skill_name }}</span>
+                            </li>
+                          {% endfor %}
+                        </ul>
+                      {% else %}
+                        <p class="muted">{% trans "Навыки пока не добавлены." %}</p>
+                      {% endif %}
+                    </article>
+                  {% endfor %}
+                </div>
+              {% else %}
+                <p class="muted">{% trans "Группы навыков пока не добавлены." %}</p>
+              {% endif %}
+            </section>
+
+            <section id="types-{{ exam.id }}" class="exam-panel" role="tabpanel" hidden>
+              {% if exam.task_types %}
+                <ul class="exam-types">
+                  {% for task_type in exam.task_types %}
+                    <li class="exam-type">
+                      <div>
+                        <h3 class="exam-type__title">{% blocktrans with name=task_type.name %}Тип {{ name }}{% endblocktrans %}</h3>
+                        {% if task_type.description %}
+                          <p class="exam-type__description">{{ task_type.description }}</p>
+                        {% endif %}
+                      </div>
+                      <span class="exam-type__count">{{ task_type.task_count }}</span>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <p class="muted">{% trans "Типы заданий пока не добавлены." %}</p>
+              {% endif %}
+            </section>
+
+            <section id="stats-{{ exam.id }}" class="exam-panel" role="tabpanel" hidden>
+              <ul class="exam-stats">
+                <li>
+                  <span class="exam-stats__value">{{ exam.stats.group_count }}</span>
+                  <span class="exam-stats__label">{% trans "групп навыков" %}</span>
+                </li>
+                <li>
+                  <span class="exam-stats__value">{{ exam.stats.skill_count }}</span>
+                  <span class="exam-stats__label">{% trans "навыков" %}</span>
+                </li>
+                <li>
+                  <span class="exam-stats__value">{{ exam.stats.task_type_count }}</span>
+                  <span class="exam-stats__label">{% trans "типов заданий" %}</span>
+                </li>
+                <li>
+                  <span class="exam-stats__value">{{ exam.stats.task_count }}</span>
+                  <span class="exam-stats__label">{% trans "заданий" %}</span>
+                </li>
+              </ul>
+            </section>
+          </div>
+        </article>
+      {% endfor %}
+    {% else %}
+      <p class="muted">{% trans "Экзамены ещё не добавлены." %}</p>
+    {% endif %}
+  </div>
 {% endblock %}

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,6 +1,7 @@
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
-from django.contrib.auth import get_user_model
 
 User = get_user_model()
 
@@ -49,3 +50,25 @@ class DashboardSettingsTests(TestCase):
             },
         )
         self.assertContains(response, "Этот логин уже занят")
+
+
+class DashboardSubjectsTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="student", password="pass", email="student@example.com"
+        )
+        call_command("seed_ege")
+
+    def test_exam_context_contains_stats(self):
+        self.client.login(username="student", password="pass")
+        response = self.client.get(reverse("accounts:dashboard-subjects"))
+        self.assertEqual(response.status_code, 200)
+        exams = response.context.get("exams", [])
+        self.assertTrue(exams)
+        exam = next((exam for exam in exams if exam["name"] == "ЕГЭ 2026"), None)
+        self.assertIsNotNone(exam)
+        self.assertGreater(exam["stats"]["skill_count"], 0)
+        self.assertGreater(exam["stats"]["task_type_count"], 0)
+        self.assertGreater(exam["stats"]["task_count"], 0)
+        self.assertTrue(exam["skill_groups"])
+        self.assertTrue(exam["task_types"])

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,9 +1,19 @@
+from collections import defaultdict
+
 from django.contrib.auth import login, update_session_auth_hash
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render, redirect
+from django.db.models import Prefetch
+from django.shortcuts import redirect, render
 
+from apps.recsys.models import (
+    ExamVersion,
+    SkillGroup,
+    SkillGroupItem,
+    Task,
+    TaskType,
+)
 
-from .forms import SignupForm, UserUpdateForm, PasswordChangeForm
+from .forms import PasswordChangeForm, SignupForm, UserUpdateForm
 
 
 def _get_dashboard_role(request):
@@ -104,7 +114,96 @@ def dashboard_settings(request):
 def dashboard_subjects(request):
     """Display a placeholder subjects dashboard."""
     role = _get_dashboard_role(request)
-    context = {"active_tab": "subjects", "role": role}
+
+    skill_items = Prefetch(
+        "items",
+        queryset=SkillGroupItem.objects.select_related("skill").order_by("order"),
+    )
+    skill_groups_prefetch = Prefetch(
+        "skill_groups",
+        queryset=SkillGroup.objects.prefetch_related(skill_items).order_by("id"),
+    )
+
+    exams = list(
+        ExamVersion.objects.select_related("subject")
+        .prefetch_related(skill_groups_prefetch)
+        .order_by("name")
+    )
+
+    exam_ids = [exam.id for exam in exams]
+    subject_ids = {exam.subject_id for exam in exams}
+
+    task_types_map = {
+        task_type.id: task_type
+        for task_type in TaskType.objects.filter(subject_id__in=subject_ids)
+    }
+
+    tasks_by_exam: dict[int, list[Task]] = defaultdict(list)
+    for task in Task.objects.filter(exam_version_id__in=exam_ids).select_related(
+        "type"
+    ):
+        tasks_by_exam[task.exam_version_id].append(task)
+
+    exam_contexts = []
+    for exam in exams:
+        groups_data = []
+        for group in exam.skill_groups.all():
+            groups_data.append(
+                {
+                    "title": group.title,
+                    "items": [
+                        {
+                            "label": item.label,
+                            "skill_name": item.skill.name,
+                        }
+                        for item in group.items.all()
+                    ],
+                }
+            )
+
+        type_counts: dict[int, int] = defaultdict(int)
+        for task in tasks_by_exam.get(exam.id, []):
+            type_counts[task.type_id] += 1
+
+        type_entries = []
+        for type_id, count in type_counts.items():
+            task_type = task_types_map.get(type_id)
+            if task_type is None:
+                continue
+            type_entries.append(
+                {
+                    "id": type_id,
+                    "name": task_type.name,
+                    "description": task_type.description,
+                    "task_count": count,
+                }
+            )
+
+        type_entries.sort(key=lambda entry: entry["name"])
+
+        stats = {
+            "group_count": len(groups_data),
+            "skill_count": sum(len(group["items"]) for group in groups_data),
+            "task_type_count": len(type_entries),
+            "task_count": sum(entry["task_count"] for entry in type_entries),
+        }
+
+        exam_contexts.append(
+            {
+                "id": exam.id,
+                "name": exam.name,
+                "subject": exam.subject.name,
+                "skill_groups": groups_data,
+                "task_types": type_entries,
+                "stats": stats,
+            }
+        )
+
+    context = {
+        "active_tab": "subjects",
+        "role": role,
+        "exams": exam_contexts,
+    }
     return render(request, "accounts/dashboard/subjects.html", context)
 
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -248,6 +248,47 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .role-toggle label { flex:1; text-align:center; padding:10px 0; border:1px solid var(--border); border-radius:10px; background:var(--card); cursor:pointer; }
 .role-toggle input:checked + label { background:var(--accent); color:#001420; border-color:color-mix(in srgb, var(--accent) 70%, black); }
 
+/* Dashboard subjects */
+.exam-section { display:grid; gap:var(--space-xl); }
+.exam-card { display:grid; gap:var(--space-lg); }
+.exam-card__header { display:flex; justify-content:space-between; gap:var(--space-lg); flex-wrap:wrap; align-items:flex-start; }
+.exam-card__title { margin:0; font-size:clamp(22px, 3vw, 32px); }
+.exam-card__subtitle { margin:var(--space-xs) 0 0; color:var(--muted); }
+.exam-card__stats-preview { display:flex; gap:var(--space-md); flex-wrap:wrap; align-items:center; }
+.exam-card__stat { display:flex; flex-direction:column; align-items:flex-start; gap:var(--space-xs); padding:var(--space-sm) var(--space-md); border:1px solid var(--border); border-radius:12px; background:rgba(58,160,255,0.08); }
+.exam-card__stat-value { font-size:20px; font-weight:700; }
+.exam-card__stat-label { font-size:var(--font-sm); color:var(--muted); text-transform:uppercase; letter-spacing:0.08em; }
+.exam-tabs { display:flex; gap:var(--space-sm); flex-wrap:wrap; }
+.exam-tab { padding:10px 16px; border-radius:999px; border:1px solid var(--border); background:#0b1017; color:var(--text); font-weight:600; cursor:pointer; transition:all 0.2s ease; }
+.exam-tab:hover { border-color:color-mix(in srgb, var(--accent) 60%, var(--border)); }
+.exam-tab.is-active { background:var(--accent); color:#001420; border-color:color-mix(in srgb, var(--accent) 70%, black); box-shadow:0 6px 18px color-mix(in srgb, var(--accent) 25%, transparent); }
+.exam-panels { display:grid; gap:var(--space-lg); }
+.exam-panel { display:none; }
+.exam-panel.is-active { display:block; }
+.exam-groups { display:grid; gap:var(--space-lg); }
+.exam-group { border:1px solid var(--border); border-radius:12px; padding:var(--space-lg); background:#0f151d; }
+.exam-group__title { margin:0 0 var(--space-sm); font-size:var(--font-lg); }
+.exam-skill-list { list-style:none; margin:0; padding:0; display:grid; gap:var(--space-sm); }
+.exam-skill { display:flex; justify-content:space-between; gap:var(--space-sm); padding:var(--space-sm) var(--space-md); border-radius:10px; background:#0b1017; border:1px solid color-mix(in srgb, var(--accent) 20%, var(--border)); }
+.exam-skill__label { font-weight:600; }
+.exam-skill__hint { color:var(--muted); font-size:var(--font-sm); }
+.exam-types { list-style:none; margin:0; padding:0; display:grid; gap:var(--space-sm); }
+.exam-type { display:flex; justify-content:space-between; gap:var(--space-lg); align-items:center; padding:var(--space-md); border-radius:12px; border:1px solid var(--border); background:#0f151d; }
+.exam-type__title { margin:0; font-size:var(--font-lg); }
+.exam-type__description { margin:var(--space-xs) 0 0; color:var(--muted); }
+.exam-type__count { font-weight:700; font-size:24px; color:var(--accent); }
+.exam-stats { list-style:none; margin:0; padding:0; display:grid; gap:var(--space-sm); grid-template-columns:repeat(auto-fit, minmax(160px, 1fr)); }
+.exam-stats li { border:1px solid var(--border); border-radius:12px; padding:var(--space-lg) var(--space-md); background:#0f151d; display:grid; gap:var(--space-xs); justify-items:center; }
+.exam-stats__value { font-size:24px; font-weight:700; }
+.exam-stats__label { color:var(--muted); text-align:center; font-size:var(--font-sm); text-transform:uppercase; letter-spacing:0.05em; }
+
+@media (max-width: 640px) {
+  .exam-card__header { flex-direction:column; }
+  .exam-card__stats-preview { width:100%; justify-content:space-between; }
+  .exam-type { flex-direction:column; align-items:flex-start; }
+  .exam-type__count { align-self:flex-end; }
+}
+
 
 /* Utility */
 .sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -90,6 +90,32 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.exam-card').forEach((card) => {
+    const tabs = Array.from(card.querySelectorAll('.exam-tab'));
+    const panels = Array.from(card.querySelectorAll('.exam-panel'));
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const targetId = tab.getAttribute('data-target');
+        tabs.forEach((btn) => {
+          const isActive = btn === tab;
+          btn.classList.toggle('is-active', isActive);
+          btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        });
+        panels.forEach((panel) => {
+          const isActive = panel.id === targetId;
+          panel.classList.toggle('is-active', isActive);
+          if (isActive) {
+            panel.removeAttribute('hidden');
+          } else {
+            panel.setAttribute('hidden', '');
+          }
+        });
+      });
+    });
+  });
+});
+
 if (typeof module !== 'undefined') {
   module.exports = { updatePrice };
 }


### PR DESCRIPTION
## Summary
- show exam name, skills, task types and stats inside a single block on the subjects dashboard
- compute exam context in the dashboard view and add regression coverage for the new data
- add styling and tab behavior fixes so the statistics tab highlights correctly

## Testing
- python manage.py test accounts

------
https://chatgpt.com/codex/tasks/task_e_68cd69e805ac832dbdb60616c6885294