### PR TITLE
Wrap exam statistics in unified card and fix active tab

### DIFF
--- a/accounts/templates/accounts/dashboard/subjects.html
+++ b/accounts/templates/accounts/dashboard/subjects.html
@@ -5,70 +5,78 @@
 
 {% block dashboard_content %}
 {% for item in exam_statistics %}
-  {% with subj=item.subject exam=item.exam_version %}
+  {% with exam=item.exam_version %}
   <section class="section">
-    <div class="section-title">
-      <span class="dot"></span>
-      <span>{{ subj.name }} — {{ exam.name }}</span>
-    </div>
-
-    {% if item.groups %}
-      {% for group in item.groups %}
-        <div class="group">
-          <h3>{{ group.title }}</h3>
-          <div class="grid">
-            {% for gi in group.items.all %}
-              {% with m=item.skill_masteries|get_item:gi.skill.id %}
-              {% with pct=m|default:0|mul:100 %}
-              <div class="item">
-                <div class="label">
-                  <span>{{ gi.skill.name }}</span>
-                  <span class="pct">{{ pct|floatformat:0 }}%</span>
-                </div>
-                <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ pct|floatformat:0 }}" aria-label="{{ gi.skill.name }}">
-                  <div class="fill" style="width: {{ pct }}%"></div>
-                </div>
-              </div>
-              {% endwith %}
-              {% endwith %}
-            {% endfor %}
-          </div>
-        </div>
-      {% endfor %}
-    {% else %}
-      <div class="group">
-        <h3>Скиллы</h3>
-        <p class="muted">Группы для этого предмета ещё не настроены.</p>
+    <div class="exam-card">
+      <div class="section-title exam-card__title">
+        <span class="dot"></span>
+        <span>{{ exam.name }}</span>
       </div>
-    {% endif %}
 
-    <div class="section-title mt-12">
-      <span class="dot"></span>
-      <span>Типы заданий</span>
-    </div>
-    {% if item.types %}
-      <div class="group">
-        <div class="grid">
-          {% for t in item.types %}
-            {% with m=item.type_masteries|get_item:t.id %}
-            {% with pct=m|default:0|mul:100 %}
-            <div class="item">
-              <div class="label">
-                <span>{{ t.name }}</span>
-                <span class="pct">{{ pct|floatformat:0 }}%</span>
-              </div>
-              <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ pct|floatformat:0 }}" aria-label="{{ t.name }}">
-                <div class="fill" style="width: {{ pct }}%"></div>
+      <div class="exam-card__section">
+        {% if item.groups %}
+          {% for group in item.groups %}
+            <div class="exam-panel">
+              <h3>{{ group.title }}</h3>
+              <div class="grid">
+                {% for gi in group.items.all %}
+                  {% with m=item.skill_masteries|get_item:gi.skill.id %}
+                  {% with pct=m|default:0|mul:100 %}
+                  <div class="item">
+                    <div class="label">
+                      <span>{{ gi.skill.name }}</span>
+                      <span class="pct">{{ pct|floatformat:0 }}%</span>
+                    </div>
+                    <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ pct|floatformat:0 }}" aria-label="{{ gi.skill.name }}">
+                      <div class="fill" style="width: {{ pct }}%"></div>
+                    </div>
+                  </div>
+                  {% endwith %}
+                  {% endwith %}
+                {% endfor %}
               </div>
             </div>
-            {% endwith %}
-            {% endwith %}
           {% endfor %}
-        </div>
+        {% else %}
+          <div class="exam-panel">
+            <h3>Скиллы</h3>
+            <p class="muted">Группы для этого предмета ещё не настроены.</p>
+          </div>
+        {% endif %}
       </div>
-    {% else %}
-      <p class="muted">Типы заданий не найдены.</p>
-    {% endif %}
+
+      <div class="section-title exam-card__title">
+        <span class="dot"></span>
+        <span>Типы заданий</span>
+      </div>
+      <div class="exam-card__section">
+        {% if item.types %}
+          <div class="exam-panel">
+            <div class="grid">
+              {% for t in item.types %}
+                {% with m=item.type_masteries|get_item:t.id %}
+                {% with pct=m|default:0|mul:100 %}
+                <div class="item">
+                  <div class="label">
+                    <span>{{ t.name }}</span>
+                    <span class="pct">{{ pct|floatformat:0 }}%</span>
+                  </div>
+                  <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ pct|floatformat:0 }}" aria-label="{{ t.name }}">
+                    <div class="fill" style="width: {{ pct }}%"></div>
+                  </div>
+                </div>
+                {% endwith %}
+                {% endwith %}
+              {% endfor %}
+            </div>
+          </div>
+        {% else %}
+          <div class="exam-panel">
+            <p class="muted">Типы заданий не найдены.</p>
+          </div>
+        {% endif %}
+      </div>
+    </div>
   </section>
   {% endwith %}
 {% empty %}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -284,7 +284,7 @@ def dashboard_subjects(request):
         )
 
     context = {
-        "active_tab": "subjects",
+        "active_tab": "statistics",
         "role": role,
         "exam_statistics": exam_statistics,
     }

--- a/static/css/cyber.css
+++ b/static/css/cyber.css
@@ -42,10 +42,30 @@ section{margin:28px 0;}
 .section-title{display:flex; align-items:center; gap:10px; font-weight:700; letter-spacing:.5px; text-transform:uppercase; color:var(--muted);}
 .section-title .dot{width:8px; height:8px; border-radius:50%; background:var(--accent); box-shadow:0 0 10px rgba(0,255,156,.6);}    
 
-.group{border:1px solid var(--outline); border-radius:16px; background:linear-gradient(180deg,#0e1512,#0b120f);
-  padding:16px; box-shadow: var(--shadow);}
-.group + .group{margin-top:14px;}
-.group h3{margin:4px 0 14px; font-size:18px; color:var(--accent); letter-spacing:.4px;}
+.exam-card{
+  border:1px solid var(--outline);
+  border-radius:20px;
+  background:linear-gradient(180deg, rgba(17,25,22,0.92), rgba(9,14,12,0.95));
+  padding:24px 20px;
+  box-shadow: var(--shadow);
+  display:grid;
+  gap:18px;
+}
+.exam-card__title{margin:0;}
+.exam-card .section-title{margin:0;}
+.exam-card__section{display:grid; gap:14px;}
+.exam-panel{
+  border:1px solid var(--outline);
+  border-radius:16px;
+  background:linear-gradient(180deg,#0e1512,#0b120f);
+  padding:16px;
+  box-shadow: var(--shadow);
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+}
+.exam-panel h3{margin:4px 0 0; font-size:18px; color:var(--accent); letter-spacing:.4px;}
+.exam-panel h3 + .grid{margin-top:6px;}
 
 .grid{display:grid; gap:12px; grid-template-columns: repeat(1, minmax(0,1fr));}
 @media (min-width:700px){ .grid{ grid-template-columns: repeat(2, minmax(0,1fr)); }}


### PR DESCRIPTION
## Summary
- wrap each exam's statistics in a single card so the heading, skills, and task types share one visual block
- simplify the exam header to display only the exam name
- ensure the statistics tab is highlighted when open and add styling for the new exam card layout

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cd6fc88b60832d86934056ea41e40b