### PR TITLE
Add variant attempt API with serializers and tests

### DIFF
--- a/apps/recsys/api/urls.py
+++ b/apps/recsys/api/urls.py
@@ -3,11 +3,17 @@ from django.urls import path
 
 from .views import (
     AttemptCreateView,
+    CurrentVariantAssignmentListView,
     NextTaskView,
+    PastVariantAssignmentListView,
     ProgressView,
     SkillListView,
     SkillGroupListView,
     TaskTypeListView,
+    VariantAssignmentHistoryView,
+    VariantAttemptFinalizeView,
+    VariantAttemptStartView,
+    VariantTaskSubmitView,
 )
 
 
@@ -21,6 +27,37 @@ urlpatterns = [
         "api/exam-versions/<int:exam_version_id>/skill-groups/",
         SkillGroupListView.as_view(),
         name="skill-group-list",
+    ),
+    # Variant workflow endpoints – all require authenticated students.
+    path(
+        "api/variants/assignments/current/",
+        CurrentVariantAssignmentListView.as_view(),
+        name="variant-assignments-current",
+    ),
+    path(
+        "api/variants/assignments/past/",
+        PastVariantAssignmentListView.as_view(),
+        name="variant-assignments-past",
+    ),
+    path(
+        "api/variants/assignments/<int:assignment_id>/attempts/start/",
+        VariantAttemptStartView.as_view(),
+        name="variant-attempt-start",
+    ),
+    path(
+        "api/variants/attempts/<int:attempt_id>/tasks/<int:variant_task_id>/submit/",
+        VariantTaskSubmitView.as_view(),
+        name="variant-task-submit",
+    ),
+    path(
+        "api/variants/attempts/<int:attempt_id>/finalize/",
+        VariantAttemptFinalizeView.as_view(),
+        name="variant-attempt-finalize",
+    ),
+    path(
+        "api/variants/assignments/<int:assignment_id>/history/",
+        VariantAssignmentHistoryView.as_view(),
+        name="variant-assignment-history",
     ),
 ]
 

--- a/apps/recsys/service_utils/variants.py
+++ b/apps/recsys/service_utils/variants.py
@@ -1,0 +1,324 @@
+"""Business logic for working with exam variants.
+
+The module contains helper functions that encapsulate the rules around variant
+assignments and attempts.  Views use these helpers to keep the HTTP layer
+simple while the behaviour is centralised and easy to unit test.  The
+functions intentionally operate on model instances instead of raw dictionaries
+so that serializers can decide how to present the data.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Iterable, List
+
+from django.db import transaction
+from django.db.models import Prefetch
+from django.utils import timezone
+from rest_framework import exceptions
+
+from apps.recsys.models import (
+    VariantAssignment,
+    VariantAttempt,
+    VariantTask,
+    VariantTaskAttempt,
+)
+
+
+TASK_PREFETCH = Prefetch(
+    "template__template_tasks",
+    queryset=VariantTask.objects.select_related("task").order_by("order"),
+)
+
+TASK_ATTEMPTS_PREFETCH = Prefetch(
+    "task_attempts",
+    queryset=VariantTaskAttempt.objects.select_related("variant_task").order_by(
+        "variant_task_id", "attempt_number", "id"
+    ),
+)
+
+ATTEMPTS_PREFETCH = Prefetch(
+    "attempts",
+    queryset=VariantAttempt.objects.order_by("attempt_number").prefetch_related(
+        TASK_ATTEMPTS_PREFETCH
+    ),
+)
+
+ASSIGNMENT_TEMPLATE_PREFETCH = Prefetch(
+    "assignment__template__template_tasks",
+    queryset=VariantTask.objects.select_related("task").order_by("order"),
+)
+
+
+def _base_assignment_queryset():
+    return (
+        VariantAssignment.objects.select_related("template")
+        .prefetch_related(TASK_PREFETCH, ATTEMPTS_PREFETCH)
+        .order_by("-created_at")
+    )
+
+
+def get_assignments_for_user(user) -> List[VariantAssignment]:
+    """Return all assignments for ``user`` with related data prefetched."""
+
+    return list(_base_assignment_queryset().filter(user=user))
+
+
+def _active_attempts(assignment: VariantAssignment) -> List[VariantAttempt]:
+    return [attempt for attempt in assignment.attempts.all() if attempt.completed_at is None]
+
+
+def _attempts_left(assignment: VariantAssignment) -> int | None:
+    template_limit = assignment.template.max_attempts
+    if template_limit is None:
+        return None
+    used = assignment.attempts.count()
+    remaining = template_limit - used
+    return max(0, remaining)
+
+
+def _deadline_passed(assignment: VariantAssignment) -> bool:
+    return bool(assignment.deadline and assignment.deadline < timezone.now())
+
+
+def can_start_attempt(assignment: VariantAssignment) -> bool:
+    """Return ``True`` if a new attempt can be started for ``assignment``."""
+
+    if _deadline_passed(assignment):
+        return False
+
+    if _active_attempts(assignment):
+        return False
+
+    remaining = _attempts_left(assignment)
+    if remaining is None:
+        return True
+    return remaining > 0
+
+
+def split_assignments(assignments: Iterable[VariantAssignment]):
+    """Split assignments into current and past buckets."""
+
+    current: list[VariantAssignment] = []
+    past: list[VariantAssignment] = []
+
+    for assignment in assignments:
+        if _active_attempts(assignment) or can_start_attempt(assignment):
+            current.append(assignment)
+        else:
+            past.append(assignment)
+
+    return current, past
+
+
+def get_assignment_or_404(user, assignment_id: int) -> VariantAssignment:
+    try:
+        assignment = _base_assignment_queryset().get(user=user, pk=assignment_id)
+    except VariantAssignment.DoesNotExist as exc:  # pragma: no cover - defensive
+        raise exceptions.NotFound("Назначение варианта не найдено") from exc
+    return assignment
+
+
+def _ensure_active_attempt(attempt: VariantAttempt) -> None:
+    if attempt.completed_at is not None:
+        raise exceptions.ValidationError("Попытка уже завершена")
+
+
+def _ensure_time_limit_allows_submission(attempt: VariantAttempt) -> None:
+    time_limit = attempt.assignment.template.time_limit
+    if not time_limit:
+        return
+    elapsed = timezone.now() - attempt.started_at
+    if elapsed > time_limit:
+        raise exceptions.ValidationError("Время на выполнение попытки истекло")
+
+
+@transaction.atomic
+def start_new_attempt(user, assignment_id: int) -> VariantAttempt:
+    """Start a new attempt for ``assignment_id`` owned by ``user``."""
+
+    try:
+        assignment = (
+            VariantAssignment.objects.select_for_update()
+            .select_related("template")
+            .get(user=user, pk=assignment_id)
+        )
+    except VariantAssignment.DoesNotExist as exc:
+        raise exceptions.NotFound("Назначение варианта не найдено") from exc
+
+    if assignment.deadline and assignment.deadline < timezone.now():
+        raise exceptions.ValidationError("Дедлайн по варианту истёк")
+
+    if assignment.attempts.filter(completed_at__isnull=True).exists():
+        raise exceptions.ValidationError("У вас уже есть активная попытка")
+
+    template_limit = assignment.template.max_attempts
+    next_number = assignment.attempts.count() + 1
+    if template_limit is not None and next_number > template_limit:
+        raise exceptions.ValidationError("Достигнут лимит попыток для варианта")
+
+    assignment.mark_started()
+    attempt = VariantAttempt.objects.create(
+        assignment=assignment,
+        attempt_number=next_number,
+    )
+
+    return attempt
+
+
+@dataclass
+class TaskSubmissionResult:
+    attempt: VariantAttempt
+    task_attempt: VariantTaskAttempt
+
+
+def _validate_variant_task(assignment: VariantAssignment, variant_task_id: int) -> VariantTask:
+    try:
+        variant_task = assignment.template.template_tasks.get(pk=variant_task_id)
+    except VariantTask.DoesNotExist as exc:
+        raise exceptions.ValidationError("Задание не относится к выбранному варианту") from exc
+    return variant_task
+
+
+@transaction.atomic
+def submit_task_answer(
+    user,
+    attempt_id: int,
+    variant_task_id: int,
+    *,
+    is_correct: bool,
+    task_snapshot: dict | None = None,
+) -> TaskSubmissionResult:
+    """Persist an answer for a concrete task inside ``attempt``."""
+
+    try:
+        attempt = (
+            VariantAttempt.objects.select_for_update()
+            .select_related("assignment__template")
+            .prefetch_related(TASK_ATTEMPTS_PREFETCH)
+            .get(pk=attempt_id, assignment__user=user)
+        )
+    except VariantAttempt.DoesNotExist as exc:
+        raise exceptions.NotFound("Попытка не найдена") from exc
+
+    _ensure_active_attempt(attempt)
+    _ensure_time_limit_allows_submission(attempt)
+
+    assignment = attempt.assignment
+    variant_task = _validate_variant_task(assignment, variant_task_id)
+
+    task_attempts_qs = attempt.task_attempts.filter(variant_task=variant_task)
+    next_number = task_attempts_qs.count() + 1
+    task_limit = variant_task.max_attempts
+    if task_limit is not None and next_number > task_limit:
+        raise exceptions.ValidationError("Достигнут лимит попыток по заданию")
+
+    snapshot = task_snapshot or {"task_id": variant_task.task_id, "title": variant_task.task.title}
+
+    task_attempt = VariantTaskAttempt.objects.create(
+        variant_attempt=attempt,
+        variant_task=variant_task,
+        task=variant_task.task,
+        attempt_number=next_number,
+        is_correct=is_correct,
+        task_snapshot=snapshot,
+    )
+
+    return TaskSubmissionResult(attempt=attempt, task_attempt=task_attempt)
+
+
+@transaction.atomic
+def finalize_attempt(user, attempt_id: int) -> VariantAttempt:
+    """Mark attempt as completed and persist time spent."""
+
+    try:
+        attempt = (
+            VariantAttempt.objects.select_for_update()
+            .select_related("assignment__template")
+            .prefetch_related(TASK_ATTEMPTS_PREFETCH)
+            .get(pk=attempt_id, assignment__user=user)
+        )
+    except VariantAttempt.DoesNotExist as exc:
+        raise exceptions.NotFound("Попытка не найдена") from exc
+
+    _ensure_active_attempt(attempt)
+
+    now = timezone.now()
+    time_limit = attempt.assignment.template.time_limit
+    if time_limit and now - attempt.started_at > time_limit:
+        attempt.time_spent = time_limit
+    else:
+        attempt.time_spent = now - attempt.started_at
+    attempt.mark_completed()
+    return attempt
+
+
+def get_attempt_with_prefetch(user, attempt_id: int) -> VariantAttempt:
+    try:
+        return (
+            VariantAttempt.objects.select_related("assignment__template")
+            .prefetch_related(TASK_ATTEMPTS_PREFETCH, ASSIGNMENT_TEMPLATE_PREFETCH)
+            .get(pk=attempt_id, assignment__user=user)
+        )
+    except VariantAttempt.DoesNotExist as exc:
+        raise exceptions.NotFound("Попытка не найдена") from exc
+
+
+def get_assignment_history(user, assignment_id: int) -> VariantAssignment:
+    return get_assignment_or_404(user, assignment_id)
+
+
+def get_attempts_left(assignment: VariantAssignment) -> int | None:
+    return _attempts_left(assignment)
+
+
+def get_time_left(attempt: VariantAttempt) -> timedelta | None:
+    time_limit = attempt.assignment.template.time_limit
+    if not time_limit:
+        return None
+    elapsed = timezone.now() - attempt.started_at
+    remaining = time_limit - elapsed
+    if remaining < timedelta(0):
+        remaining = timedelta(0)
+    return remaining
+
+
+def calculate_assignment_progress(assignment: VariantAssignment) -> dict:
+    template_tasks = list(assignment.template.template_tasks.all())
+    solved_variant_task_ids = set()
+    for attempt in assignment.attempts.all():
+        for task_attempt in attempt.task_attempts.all():
+            if task_attempt.is_correct:
+                solved_variant_task_ids.add(task_attempt.variant_task_id)
+
+    return {
+        "total_tasks": len(template_tasks),
+        "solved_tasks": len(solved_variant_task_ids),
+        "remaining_tasks": max(0, len(template_tasks) - len(solved_variant_task_ids)),
+    }
+
+
+def build_tasks_progress(attempt: VariantAttempt) -> list[dict]:
+    template_tasks = list(attempt.assignment.template.template_tasks.all())
+    attempts_map: dict[int, list[VariantTaskAttempt]] = {}
+    for task_attempt in attempt.task_attempts.all():
+        attempts_map.setdefault(task_attempt.variant_task_id, []).append(task_attempt)
+
+    progress = []
+    for variant_task in template_tasks:
+        task_attempts = attempts_map.get(variant_task.id, [])
+        progress.append(
+            {
+                "variant_task_id": variant_task.id,
+                "task_id": variant_task.task_id,
+                "order": variant_task.order,
+                "max_attempts": variant_task.max_attempts,
+                "attempts": task_attempts,
+                "attempts_used": len(task_attempts),
+                "is_completed": any(attempt.is_correct for attempt in task_attempts),
+            }
+        )
+
+    progress.sort(key=lambda item: item["order"])
+    return progress
+

--- a/apps/recsys/tests/test_variant_api_flow.py
+++ b/apps/recsys/tests/test_variant_api_flow.py
@@ -1,0 +1,180 @@
+import json
+from datetime import timedelta
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from apps.recsys.models import VariantAttempt
+from . import factories
+
+
+class VariantApiFlowTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(username="student", password="pass")
+        self.client.force_login(self.user)
+
+        self.template = factories.create_variant_template(max_attempts=2, time_limit_minutes=5)
+        first_task = factories.create_task()
+        second_task = factories.create_task(subject=first_task.subject)
+        self.variant_task_1 = factories.add_variant_task(
+            template=self.template,
+            task=first_task,
+            order=1,
+            max_attempts=2,
+        )
+        self.variant_task_2 = factories.add_variant_task(
+            template=self.template,
+            task=second_task,
+            order=2,
+            max_attempts=1,
+        )
+        self.assignment = factories.assign_variant(
+            template=self.template, username=self.user.username
+        )
+
+    def test_full_variant_flow(self):
+        current_resp = self.client.get("/api/variants/assignments/current/")
+        self.assertEqual(current_resp.status_code, 200)
+        current_data = current_resp.json()
+        self.assertEqual(len(current_data), 1)
+        assignment_payload = current_data[0]
+        self.assertEqual(assignment_payload["id"], self.assignment.id)
+        self.assertIsNone(assignment_payload["active_attempt"])
+        self.assertEqual(assignment_payload["attempts_left"], 2)
+        self.assertEqual(assignment_payload["progress"]["solved_tasks"], 0)
+
+        start_resp = self.client.post(
+            f"/api/variants/assignments/{self.assignment.id}/attempts/start/"
+        )
+        self.assertEqual(start_resp.status_code, 201)
+        attempt_payload = start_resp.json()
+        self.assertEqual(attempt_payload["attempt_number"], 1)
+        self.assertIsNone(attempt_payload["completed_at"])
+        self.assertIsNotNone(attempt_payload["time_limit"])
+        attempt_id = attempt_payload["id"]
+
+        # Assignment should now expose the active attempt
+        current_resp = self.client.get("/api/variants/assignments/current/")
+        assignment_payload = current_resp.json()[0]
+        self.assertIsNotNone(assignment_payload["active_attempt"])
+        self.assertEqual(assignment_payload["attempts_left"], 1)
+
+        incorrect_payload = {
+            "is_correct": False,
+            "task_snapshot": {"question": "Q1", "chosen": "A"},
+        }
+        submit_resp = self.client.post(
+            f"/api/variants/attempts/{attempt_id}/tasks/{self.variant_task_1.id}/submit/",
+            data=json.dumps(incorrect_payload),
+            content_type="application/json",
+        )
+        self.assertEqual(submit_resp.status_code, 201)
+        progress_payload = submit_resp.json()["tasks_progress"]
+        first_task_entry = next(
+            item for item in progress_payload if item["variant_task_id"] == self.variant_task_1.id
+        )
+        self.assertEqual(first_task_entry["attempts_used"], 1)
+        self.assertFalse(first_task_entry["is_completed"])
+        self.assertEqual(
+            first_task_entry["attempts"][0]["task_snapshot"], incorrect_payload["task_snapshot"]
+        )
+
+        correct_payload = {
+            "is_correct": True,
+            "task_snapshot": {"question": "Q1", "chosen": "B"},
+        }
+        submit_resp = self.client.post(
+            f"/api/variants/attempts/{attempt_id}/tasks/{self.variant_task_1.id}/submit/",
+            data=json.dumps(correct_payload),
+            content_type="application/json",
+        )
+        self.assertEqual(submit_resp.status_code, 201)
+        first_task_entry = next(
+            item for item in submit_resp.json()["tasks_progress"]
+            if item["variant_task_id"] == self.variant_task_1.id
+        )
+        self.assertEqual(first_task_entry["attempts_used"], 2)
+        self.assertTrue(first_task_entry["is_completed"])
+
+        second_payload = {"is_correct": True, "task_snapshot": {"question": "Q2"}}
+        submit_resp = self.client.post(
+            f"/api/variants/attempts/{attempt_id}/tasks/{self.variant_task_2.id}/submit/",
+            data=json.dumps(second_payload),
+            content_type="application/json",
+        )
+        self.assertEqual(submit_resp.status_code, 201)
+        second_task_entry = next(
+            item for item in submit_resp.json()["tasks_progress"]
+            if item["variant_task_id"] == self.variant_task_2.id
+        )
+        self.assertTrue(second_task_entry["is_completed"])
+        self.assertEqual(second_task_entry["attempts_used"], 1)
+
+        finalize_resp = self.client.post(f"/api/variants/attempts/{attempt_id}/finalize/")
+        self.assertEqual(finalize_resp.status_code, 200)
+        self.assertIsNotNone(finalize_resp.json()["completed_at"])
+
+        current_resp = self.client.get("/api/variants/assignments/current/")
+        assignment_payload = current_resp.json()[0]
+        self.assertIsNone(assignment_payload["active_attempt"])
+        self.assertEqual(assignment_payload["progress"]["solved_tasks"], 2)
+        self.assertEqual(assignment_payload["attempts_left"], 1)
+
+        second_start = self.client.post(
+            f"/api/variants/assignments/{self.assignment.id}/attempts/start/"
+        )
+        self.assertEqual(second_start.status_code, 201)
+        second_attempt_id = second_start.json()["id"]
+        second_attempt = VariantAttempt.objects.get(pk=second_attempt_id)
+
+        with mock.patch("apps.recsys.service_utils.variants.timezone.now") as mocked_now:
+            mocked_now.return_value = (
+                second_attempt.started_at
+                + self.template.time_limit
+                + timedelta(minutes=1)
+            )
+            timeout_resp = self.client.post(
+                f"/api/variants/attempts/{second_attempt_id}/tasks/{self.variant_task_2.id}/submit/",
+                data=json.dumps({"is_correct": False}),
+                content_type="application/json",
+            )
+        self.assertEqual(timeout_resp.status_code, 400)
+
+        finalize_resp = self.client.post(
+            f"/api/variants/attempts/{second_attempt_id}/finalize/"
+        )
+        self.assertEqual(finalize_resp.status_code, 200)
+
+        current_resp = self.client.get("/api/variants/assignments/current/")
+        self.assertEqual(current_resp.json(), [])
+
+        past_resp = self.client.get("/api/variants/assignments/past/")
+        self.assertEqual(past_resp.status_code, 200)
+        self.assertEqual(len(past_resp.json()), 1)
+
+        third_start = self.client.post(
+            f"/api/variants/assignments/{self.assignment.id}/attempts/start/"
+        )
+        self.assertEqual(third_start.status_code, 400)
+
+        history_resp = self.client.get(
+            f"/api/variants/assignments/{self.assignment.id}/history/"
+        )
+        self.assertEqual(history_resp.status_code, 200)
+        history_payload = history_resp.json()
+        self.assertEqual(history_payload["id"], self.assignment.id)
+        self.assertEqual(len(history_payload["attempts"]), 2)
+        first_attempt_history = history_payload["attempts"][0]
+        first_task_progress = next(
+            item
+            for item in first_attempt_history["tasks_progress"]
+            if item["variant_task_id"] == self.variant_task_1.id
+        )
+        self.assertTrue(first_task_progress["is_completed"])
+        self.assertEqual(len(first_task_progress["attempts"]), 2)
+        self.assertEqual(
+            first_task_progress["attempts"][0]["task_snapshot"],
+            incorrect_payload["task_snapshot"],
+        )


### PR DESCRIPTION
## Summary
- add serializers for variant templates, assignments and attempts including progress data
- implement variant workflow API endpoints with dedicated service layer
- cover variant flow with integration tests for attempts, time limit and history

## Testing
- python manage.py test apps.recsys

------
https://chatgpt.com/codex/tasks/task_e_68ce2f34d338832d8d5ef87a155eaa51