### PR TITLE
Implement student variant assignments dashboard

### DIFF
--- a/accounts/templates/accounts/dashboard.html
+++ b/accounts/templates/accounts/dashboard.html
@@ -1,7 +1,122 @@
 {% extends 'accounts/dashboard/base.html' %}
+{% load i18n %}
 
-{% block dashboard_title %}Задания{% endblock %}
+{% block dashboard_title %}{% trans "Задания" %}{% endblock %}
 
 {% block dashboard_content %}
-<p>тут будут ваши задания</p>
+  <section class="assignments-group" aria-labelledby="current-assignments-title">
+    <div class="assignments-group__header">
+      <h2 id="current-assignments-title">{% trans "Текущие задания" %}</h2>
+      <p class="assignments-group__hint">
+        {% trans "Начните новую попытку или продолжите активную работу над вариантом." %}
+      </p>
+    </div>
+    {% if current_assignments %}
+      <div class="assignment-cards">
+        {% for item in current_assignments %}
+          <article class="assignment-card{% if item.deadline_passed %} assignment-card--overdue{% endif %}">
+            <header class="assignment-card__header">
+              <h3 class="assignment-card__title">{{ item.assignment.template.name }}</h3>
+              {% if item.deadline %}
+                <p class="assignment-card__deadline">
+                  {% blocktrans with deadline=item.deadline|date:"d E Y H:i" %}Дедлайн: {{ deadline }}{% endblocktrans %}
+                  {% if item.deadline_passed %}
+                    <span class="assignment-card__badge assignment-card__badge--danger">{% trans "истёк" %}</span>
+                  {% endif %}
+                </p>
+              {% endif %}
+            </header>
+            <div class="assignment-card__progress" role="group" aria-label="{% trans 'Прогресс по заданию' %}">
+              <div class="assignment-card__progress-bar" aria-hidden="true">
+                <span class="assignment-card__progress-value" style="width: {{ item.progress_percentage }}%"></span>
+              </div>
+              <p class="assignment-card__progress-text">
+                {% blocktrans with solved=item.progress.solved_tasks total=item.progress.total_tasks %}
+                  Решено {{ solved }} из {{ total }}
+                {% endblocktrans %}
+              </p>
+            </div>
+            <dl class="assignment-card__meta">
+              <div class="assignment-card__meta-item">
+                <dt>{% trans "Попытки" %}</dt>
+                <dd>
+                  {% if item.attempts_total %}
+                    {% blocktrans with used=item.attempts_used total=item.attempts_total %}
+                      Использовано {{ used }} из {{ total }}
+                    {% endblocktrans %}
+                    {% if item.attempts_left is not None %}
+                      <span class="assignment-card__meta-note">
+                        {% blocktrans with remaining=item.attempts_left %}Осталось {{ remaining }}{% endblocktrans %}
+                      </span>
+                    {% endif %}
+                  {% else %}
+                    {% trans "Без ограничений" %}
+                  {% endif %}
+                </dd>
+              </div>
+              {% if item.active_attempt %}
+                <div class="assignment-card__meta-item">
+                  <dt>{% trans "Активная попытка" %}</dt>
+                  <dd>#{{ item.active_attempt.attempt_number }}</dd>
+                </div>
+              {% endif %}
+            </dl>
+            <footer class="assignment-card__actions">
+              {% if item.active_attempt %}
+                <a class="btn btn-primary" href="{% url 'accounts:assignment-detail' item.assignment.id %}">{% trans "Продолжить" %}</a>
+              {% elif item.can_start %}
+                <form method="post" action="{% url 'accounts:assignment-detail' item.assignment.id %}">
+                  {% csrf_token %}
+                  <input type="hidden" name="start_attempt" value="1">
+                  <button type="submit" class="btn btn-primary">{% trans "Начать попытку" %}</button>
+                </form>
+              {% else %}
+                <span class="assignment-card__meta-note assignment-card__meta-note--warning">{% trans "Новые попытки недоступны" %}</span>
+              {% endif %}
+              <a class="btn btn-secondary" href="{% url 'accounts:assignment-detail' item.assignment.id %}">{% trans "Подробнее" %}</a>
+              <a class="btn btn-link" href="{% url 'accounts:assignment-result' item.assignment.id %}">{% trans "История" %}</a>
+            </footer>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="assignments-group__empty">{% trans "У вас пока нет активных заданий." %}</p>
+    {% endif %}
+  </section>
+
+  <section class="assignments-group" aria-labelledby="past-assignments-title">
+    <div class="assignments-group__header">
+      <h2 id="past-assignments-title">{% trans "Прошлые задания" %}</h2>
+      <p class="assignments-group__hint">{% trans "Здесь собраны завершённые или недоступные варианты." %}</p>
+    </div>
+    {% if past_assignments %}
+      <div class="assignment-cards">
+        {% for item in past_assignments %}
+          <article class="assignment-card assignment-card--compact">
+            <header class="assignment-card__header">
+              <h3 class="assignment-card__title">{{ item.assignment.template.name }}</h3>
+              {% if item.deadline %}
+                <p class="assignment-card__deadline">
+                  {% blocktrans with deadline=item.deadline|date:"d E Y H:i" %}Дедлайн: {{ deadline }}{% endblocktrans %}
+                </p>
+              {% endif %}
+            </header>
+            <div class="assignment-card__progress assignment-card__progress--inline">
+              <p class="assignment-card__progress-text">
+                {% blocktrans with solved=item.progress.solved_tasks total=item.progress.total_tasks %}
+                  Решено {{ solved }} из {{ total }}
+                {% endblocktrans %}
+              </p>
+            </div>
+            <footer class="assignment-card__actions">
+              <a class="btn btn-secondary" href="{% url 'accounts:assignment-detail' item.assignment.id %}">{% trans "Подробнее" %}</a>
+              <a class="btn btn-link" href="{% url 'accounts:assignment-result' item.assignment.id %}">{% trans "История" %}</a>
+            </footer>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="assignments-group__empty">{% trans "Завершённых заданий пока нет." %}</p>
+    {% endif %}
+  </section>
 {% endblock %}

--- a/accounts/templates/accounts/dashboard/assignment_detail.html
+++ b/accounts/templates/accounts/dashboard/assignment_detail.html
@@ -1,0 +1,124 @@
+{% extends 'accounts/dashboard/base.html' %}
+{% load i18n %}
+
+{% block dashboard_title %}{{ assignment.template.name }}{% endblock %}
+
+{% block dashboard_content %}
+  <nav class="assignment-breadcrumbs" aria-label="{% trans 'Навигация по заданиям' %}">
+    <a class="assignment-breadcrumbs__link" href="{% url 'accounts:dashboard' %}">{% trans "К заданиям" %}</a>
+  </nav>
+
+  <article class="assignment-detail">
+    <header class="assignment-detail__header">
+      <h2 class="assignment-detail__title">{{ assignment.template.name }}</h2>
+      {% if assignment_info.deadline %}
+        <p class="assignment-detail__deadline">
+          {% blocktrans with deadline=assignment_info.deadline|date:"d E Y H:i" %}Дедлайн: {{ deadline }}{% endblocktrans %}
+          {% if assignment_info.deadline_passed %}
+            <span class="assignment-detail__badge assignment-detail__badge--danger">{% trans "истёк" %}</span>
+          {% endif %}
+        </p>
+      {% endif %}
+    </header>
+
+    <section class="assignment-detail__summary" aria-label="{% trans 'Основная информация по варианту' %}">
+      <div class="assignment-detail__progress">
+        <div class="assignment-detail__progress-bar" aria-hidden="true">
+          <span class="assignment-detail__progress-value" style="width: {{ assignment_info.progress_percentage }}%"></span>
+        </div>
+        <p class="assignment-detail__progress-text">
+          {% blocktrans with solved=assignment_info.progress.solved_tasks total=assignment_info.progress.total_tasks %}
+            Решено {{ solved }} из {{ total }} заданий
+          {% endblocktrans %}
+        </p>
+      </div>
+      <dl class="assignment-detail__meta">
+        <div class="assignment-detail__meta-item">
+          <dt>{% trans "Попытки" %}</dt>
+          <dd>
+            {% if assignment_info.attempts_total %}
+              {% blocktrans with used=assignment_info.attempts_used total=assignment_info.attempts_total %}
+                Использовано {{ used }} из {{ total }}
+              {% endblocktrans %}
+              {% if assignment_info.attempts_left is not None %}
+                <span class="assignment-detail__meta-note">
+                  {% blocktrans with remaining=assignment_info.attempts_left %}Осталось {{ remaining }}{% endblocktrans %}
+                </span>
+              {% endif %}
+            {% else %}
+              {% trans "Без ограничений" %}
+            {% endif %}
+          </dd>
+        </div>
+        {% if assignment_info.active_attempt %}
+          <div class="assignment-detail__meta-item">
+            <dt>{% trans "Текущая попытка" %}</dt>
+            <dd>
+              #{{ assignment_info.active_attempt.attempt_number }} ·
+              {% blocktrans with started=assignment_info.active_attempt.started_at|date:"d E Y H:i" %}начата {{ started }}{% endblocktrans %}
+            </dd>
+          </div>
+        {% endif %}
+      </dl>
+    </section>
+
+    <section class="assignment-detail__actions" aria-label="{% trans 'Доступные действия' %}">
+      {% if assignment_info.active_attempt %}
+        <p class="assignment-detail__hint">{% trans "У вас есть активная попытка. Продолжите работу или завершите её из интерфейса решения." %}</p>
+      {% elif assignment_info.can_start %}
+        <form method="post">
+          {% csrf_token %}
+          <input type="hidden" name="start_attempt" value="1">
+          <button type="submit" class="btn btn-primary">{% trans "Начать новую попытку" %}</button>
+        </form>
+      {% else %}
+        <p class="assignment-detail__hint assignment-detail__hint--muted">{% trans "Новые попытки недоступны для этого варианта." %}</p>
+      {% endif %}
+      <a class="btn btn-secondary" href="{% url 'accounts:assignment-result' assignment.id %}">{% trans "История попыток" %}</a>
+    </section>
+
+    <section class="assignment-detail__history" aria-label="{% trans 'Список попыток' %}">
+      <h3>{% trans "Попытки" %}</h3>
+      {% if attempts %}
+        <ul class="assignment-detail__attempts">
+          {% for attempt in attempts %}
+            <li class="assignment-detail__attempt">
+              <div class="assignment-detail__attempt-header">
+                <span class="assignment-detail__attempt-number">#{{ attempt.attempt_number }}</span>
+                {% if attempt.completed_at %}
+                  <span class="assignment-detail__attempt-status assignment-detail__attempt-status--success">{% trans "Завершена" %}</span>
+                {% else %}
+                  <span class="assignment-detail__attempt-status assignment-detail__attempt-status--active">{% trans "Активна" %}</span>
+                {% endif %}
+              </div>
+              <dl class="assignment-detail__attempt-meta">
+                <div>
+                  <dt>{% trans "Начало" %}</dt>
+                  <dd>{{ attempt.started_at|date:"d E Y H:i" }}</dd>
+                </div>
+                <div>
+                  <dt>{% trans "Завершение" %}</dt>
+                  <dd>
+                    {% if attempt.completed_at %}
+                      {{ attempt.completed_at|date:"d E Y H:i" }}
+                    {% else %}
+                      {% trans "ещё в работе" %}
+                    {% endif %}
+                  </dd>
+                </div>
+                {% if attempt.time_spent %}
+                  <div>
+                    <dt>{% trans "Затраченное время" %}</dt>
+                    <dd>{{ attempt.time_spent }}</dd>
+                  </div>
+                {% endif %}
+              </dl>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="assignment-detail__empty">{% trans "Попытки ещё не начинались." %}</p>
+      {% endif %}
+    </section>
+  </article>
+{% endblock %}

--- a/accounts/templates/accounts/dashboard/assignment_result.html
+++ b/accounts/templates/accounts/dashboard/assignment_result.html
@@ -1,0 +1,72 @@
+{% extends 'accounts/dashboard/base.html' %}
+{% load i18n %}
+
+{% block dashboard_title %}{{ assignment.template.name }} — {% trans "История" %}{% endblock %}
+
+{% block dashboard_content %}
+  <nav class="assignment-breadcrumbs" aria-label="{% trans 'Навигация по заданиям' %}">
+    <a class="assignment-breadcrumbs__link" href="{% url 'accounts:dashboard' %}">{% trans "К заданиям" %}</a>
+    <a class="assignment-breadcrumbs__link" href="{% url 'accounts:assignment-detail' assignment.id %}">{% trans "К варианту" %}</a>
+  </nav>
+
+  <article class="assignment-results">
+    <header class="assignment-results__header">
+      <h2 class="assignment-results__title">{{ assignment.template.name }}</h2>
+      <p class="assignment-results__summary">
+        {% blocktrans with solved=assignment_info.progress.solved_tasks total=assignment_info.progress.total_tasks %}
+          Решено {{ solved }} из {{ total }} заданий
+        {% endblocktrans %}
+      </p>
+    </header>
+
+    <section class="assignment-results__attempts" aria-label="{% trans 'История попыток' %}">
+      <h3>{% trans "Попытки" %}</h3>
+      {% if attempts %}
+        <table class="assignment-results__table">
+          <thead>
+            <tr>
+              <th scope="col">#</th>
+              <th scope="col">{% trans "Статус" %}</th>
+              <th scope="col">{% trans "Начало" %}</th>
+              <th scope="col">{% trans "Завершение" %}</th>
+              <th scope="col">{% trans "Длительность" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for attempt in attempts %}
+              <tr class="assignment-results__row{% if not attempt.completed_at %} assignment-results__row--active{% endif %}">
+                <th scope="row">{{ attempt.attempt_number }}</th>
+                <td>
+                  {% if attempt.completed_at %}
+                    <span class="assignment-results__status assignment-results__status--success">{% trans "Завершена" %}</span>
+                  {% else %}
+                    <span class="assignment-results__status assignment-results__status--active">{% trans "Активна" %}</span>
+                  {% endif %}
+                </td>
+                <td>{{ attempt.started_at|date:"d E Y H:i" }}</td>
+                <td>
+                  {% if attempt.completed_at %}
+                    {{ attempt.completed_at|date:"d E Y H:i" }}
+                  {% else %}
+                    {% trans "—" %}
+                  {% endif %}
+                </td>
+                <td>
+                  {% if attempt.time_spent %}
+                    {{ attempt.time_spent }}
+                  {% elif attempt.completed_at %}
+                    {% trans "не сохранено" %}
+                  {% else %}
+                    {% trans "в процессе" %}
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="assignment-results__empty">{% trans "История попыток пока пуста." %}</p>
+      {% endif %}
+    </section>
+  </article>
+{% endblock %}

--- a/accounts/templates/accounts/dashboard/subjects.html
+++ b/accounts/templates/accounts/dashboard/subjects.html
@@ -10,7 +10,7 @@
     <div class="exam-card">
       <div class="section-title exam-card__title">
         <span class="dot"></span>
-        <span>{{ exam.name }}</span>
+        <span>{{ item.subject.name }} — {{ exam.name }}</span>
       </div>
 
       <div class="exam-card__section">

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -9,6 +9,16 @@ app_name = "accounts"
 urlpatterns = [
     path("signup/", views.signup, name="signup"),
     path("dashboard/", views.progress, name="dashboard"),
+    path(
+        "dashboard/assignments/<int:assignment_id>/",
+        views.assignment_detail,
+        name="assignment-detail",
+    ),
+    path(
+        "dashboard/assignments/<int:assignment_id>/results/",
+        views.assignment_result,
+        name="assignment-result",
+    ),
     path("dashboard/subjects/", views.dashboard_subjects, name="dashboard-subjects"),
     path("dashboard/courses/", views.dashboard_courses, name="dashboard-courses"),
     path("dashboard/teachers/", views.dashboard_teachers, name="dashboard-teachers"),


### PR DESCRIPTION
## Summary
- build the student assignments dashboard with current and past blocks including progress, deadline status, and actions
- add detail and history templates with start attempt handling in the views and routes
- extend dashboard subjects header and add tests covering assignment permissions and context

## Testing
- python manage.py test accounts

------
https://chatgpt.com/codex/tasks/task_e_68ce3121a610832dbf91f28ae5be65a2