### PR TITLE
Add teacher dashboard task creation tools

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -4,8 +4,12 @@ from django.contrib.auth.forms import (
     AuthenticationForm,
     PasswordChangeForm as DjangoPasswordChangeForm,
 )
+from django.forms import formset_factory
 from django.utils.translation import gettext_lazy as _
-from apps.recsys.models import ExamVersion
+
+from apps.recsys.models import ExamVersion, Skill, Task, TaskType
+from subjects.models import Subject
+
 from .models import StudentProfile
 
 User = get_user_model()
@@ -89,3 +93,154 @@ class PasswordChangeForm(DjangoPasswordChangeForm):
         self.fields["old_password"].label = _("Старый пароль")
         self.fields["new_password1"].label = _("Новый пароль")
         self.fields["new_password2"].label = _("Подтверждение нового пароля")
+
+
+class TaskCreateForm(forms.ModelForm):
+    """Form for creating a new static task from the teacher dashboard."""
+
+    correct_answer = forms.CharField(
+        label=_("Правильный ответ"),
+        required=False,
+        help_text=_("Введите текст ответа. Он будет сохранён как структура JSON."),
+        widget=forms.Textarea(attrs={"rows": 2}),
+    )
+    preliminary_difficulty = forms.IntegerField(
+        label=_("Предварительная сложность"),
+        required=False,
+        min_value=0,
+        max_value=100,
+        help_text=_("Число от 0 до 100. Сохраняется как дополнительная метка сложности."),
+    )
+
+    class Meta:
+        model = Task
+        fields = (
+            "subject",
+            "exam_version",
+            "type",
+            "title",
+            "description",
+            "image",
+            "difficulty_level",
+            "correct_answer",
+        )
+        labels = {
+            "subject": _("Предмет"),
+            "exam_version": _("Экзамен"),
+            "type": _("Тип задания"),
+            "title": _("Заголовок"),
+            "description": _("Условие"),
+            "image": _("Скриншот условия"),
+            "difficulty_level": _("Сложность"),
+        }
+        widgets = {
+            "description": forms.Textarea(attrs={"rows": 6}),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["exam_version"].queryset = ExamVersion.objects.select_related("subject").order_by(
+            "subject__name", "name"
+        )
+        self.fields["type"].queryset = TaskType.objects.select_related("subject").order_by(
+            "subject__name", "name"
+        )
+        self.fields["subject"].queryset = Subject.objects.order_by("name")
+        self.fields["difficulty_level"].min_value = 0
+        self.fields["difficulty_level"].max_value = 100
+        self.fields["difficulty_level"].help_text = _("Число от 0 до 100.")
+
+    def clean(self):
+        cleaned_data = super().clean()
+        subject = cleaned_data.get("subject")
+        exam = cleaned_data.get("exam_version")
+        task_type = cleaned_data.get("type")
+        description = cleaned_data.get("description")
+        image = cleaned_data.get("image")
+
+        if not description and not image:
+            raise forms.ValidationError(
+                _("Добавьте текст условия или загрузите скриншот."),
+            )
+
+        if subject:
+            if exam and exam.subject_id != subject.id:
+                self.add_error(
+                    "exam_version",
+                    _("Версия экзамена должна относиться к выбранному предмету."),
+                )
+            if task_type and task_type.subject_id != subject.id:
+                self.add_error(
+                    "type",
+                    _("Тип задания должен относиться к выбранному предмету."),
+                )
+
+        return cleaned_data
+
+    def clean_correct_answer(self):
+        answer_text = self.cleaned_data.get("correct_answer")
+        if not answer_text:
+            return {}
+        return {"text": answer_text.strip()}
+
+    def save(self, commit: bool = True):
+        task = super().save(commit=False)
+        preliminary = self.cleaned_data.get("preliminary_difficulty")
+        payload = dict(task.default_payload or {})
+        if preliminary is not None:
+            payload["preliminary_difficulty"] = preliminary
+        task.default_payload = payload
+        if commit:
+            task.save()
+        return task
+
+
+class TaskSkillForm(forms.Form):
+    """Form for selecting skills linked to a task."""
+
+    skill = forms.ModelChoiceField(
+        label=_("Умение"),
+        queryset=Skill.objects.none(),
+        required=False,
+    )
+    weight = forms.DecimalField(
+        label=_("Вес умения"),
+        required=False,
+        min_value=0,
+        max_value=10,
+        decimal_places=2,
+        initial=1,
+        help_text=_("Вес влияет на вклад умения в задачу."),
+    )
+
+    def set_subject(self, subject: Subject | None) -> None:
+        queryset = Skill.objects.select_related("subject").order_by("subject__name", "name")
+        if subject:
+            queryset = queryset.filter(subject=subject)
+        self.fields["skill"].queryset = queryset
+
+    def clean(self):
+        cleaned_data = super().clean()
+        skill = cleaned_data.get("skill")
+        weight = cleaned_data.get("weight")
+
+        if not skill:
+            cleaned_data["weight"] = None
+            return cleaned_data
+
+        if weight is None:
+            cleaned_data["weight"] = self.fields["weight"].initial
+
+        return cleaned_data
+
+
+TaskSkillFormSet = formset_factory(TaskSkillForm, extra=3, can_delete=True)
+
+
+def build_task_skill_formset(*, subject: Subject | None, data=None, prefix: str = "skills"):
+    """Return a formset configured for the given subject."""
+
+    formset = TaskSkillFormSet(data=data, prefix=prefix)
+    for form in formset.forms:
+        form.set_subject(subject)
+    return formset

--- a/accounts/templates/accounts/dashboard/base.html
+++ b/accounts/templates/accounts/dashboard/base.html
@@ -29,6 +29,11 @@
       <li class="{% if active_tab == 'courses' %}active{% endif %}" role="presentation">
         <a role="tab" aria-selected="{% if active_tab == 'courses' %}true{% else %}false{% endif %}" href="{% url 'accounts:dashboard-courses' %}">{% trans 'Курсы' %}</a>
       </li>
+      {% if role == 'teacher' %}
+        <li class="{% if active_tab == 'teachers' %}active{% endif %}" role="presentation">
+          <a role="tab" aria-selected="{% if active_tab == 'teachers' %}true{% else %}false{% endif %}" href="{% url 'accounts:dashboard-teachers' %}">{% trans 'Учительская' %}</a>
+        </li>
+      {% endif %}
       <li class="{% if active_tab == 'settings' %}active{% endif %}" role="presentation">
         <a role="tab" aria-selected="{% if active_tab == 'settings' %}true{% else %}false{% endif %}" href="{% url 'accounts:dashboard-settings' %}">{% trans 'Настройки' %}</a>
       </li>

--- a/accounts/templates/accounts/dashboard/teachers.html
+++ b/accounts/templates/accounts/dashboard/teachers.html
@@ -1,11 +1,103 @@
 {% extends 'accounts/dashboard/base.html' %}
+{% load i18n %}
 
-{% block dashboard_title %}{% if role == 'teacher' %}Мои ученики{% else %}Мои учителя{% endif %}{% endblock %}
+{% block dashboard_title %}{% trans "Учительская" %}{% endblock %}
 
 {% block dashboard_content %}
-{% if role == 'teacher' %}
-<p>Здесь будет список учеников.</p>
-{% else %}
-<p>Здесь будет список учителей.</p>
-{% endif %}
+  {% if role != 'teacher' %}
+    <section class="card">
+      <h2 class="mb-8">{% trans "Доступ ограничен" %}</h2>
+      <p class="muted">{% trans "Учительская доступна только пользователям с ролью преподавателя." %}</p>
+    </section>
+  {% else %}
+    <section class="card">
+      <h2 class="mb-16">{% trans "Добавить задачу" %}</h2>
+      <form method="post" enctype="multipart/form-data" class="teacher-task-form">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        <div class="form-grid">
+          <div class="form-field">
+            <label for="{{ form.subject.id_for_label }}">{{ form.subject.label }}</label>
+            {{ form.subject }}
+            {% if form.subject.errors %}<div class="errorlist">{{ form.subject.errors }}</div>{% endif %}
+          </div>
+          <div class="form-field">
+            <label for="{{ form.exam_version.id_for_label }}">{{ form.exam_version.label }}</label>
+            {{ form.exam_version }}
+            {% if form.exam_version.help_text %}<p class="hint">{{ form.exam_version.help_text }}</p>{% endif %}
+            {% if form.exam_version.errors %}<div class="errorlist">{{ form.exam_version.errors }}</div>{% endif %}
+          </div>
+          <div class="form-field">
+            <label for="{{ form.type.id_for_label }}">{{ form.type.label }}</label>
+            {{ form.type }}
+            {% if form.type.errors %}<div class="errorlist">{{ form.type.errors }}</div>{% endif %}
+          </div>
+          <div class="form-field">
+            <label for="{{ form.title.id_for_label }}">{{ form.title.label }}</label>
+            {{ form.title }}
+            {% if form.title.errors %}<div class="errorlist">{{ form.title.errors }}</div>{% endif %}
+          </div>
+          <div class="form-field form-field--wide">
+            <label for="{{ form.description.id_for_label }}">{{ form.description.label }}</label>
+            {{ form.description }}
+            {% if form.description.errors %}<div class="errorlist">{{ form.description.errors }}</div>{% endif %}
+          </div>
+          <div class="form-field">
+            <label for="{{ form.image.id_for_label }}">{{ form.image.label }}</label>
+            {{ form.image }}
+            {% if form.image.errors %}<div class="errorlist">{{ form.image.errors }}</div>{% endif %}
+          </div>
+          <div class="form-field">
+            <label for="{{ form.difficulty_level.id_for_label }}">{{ form.difficulty_level.label }}</label>
+            {{ form.difficulty_level }}
+            {% if form.difficulty_level.help_text %}<p class="hint">{{ form.difficulty_level.help_text }}</p>{% endif %}
+            {% if form.difficulty_level.errors %}<div class="errorlist">{{ form.difficulty_level.errors }}</div>{% endif %}
+          </div>
+          <div class="form-field">
+            <label for="{{ form.preliminary_difficulty.id_for_label }}">{{ form.preliminary_difficulty.label }}</label>
+            {{ form.preliminary_difficulty }}
+            {% if form.preliminary_difficulty.help_text %}<p class="hint">{{ form.preliminary_difficulty.help_text }}</p>{% endif %}
+            {% if form.preliminary_difficulty.errors %}<div class="errorlist">{{ form.preliminary_difficulty.errors }}</div>{% endif %}
+          </div>
+          <div class="form-field form-field--wide">
+            <label for="{{ form.correct_answer.id_for_label }}">{{ form.correct_answer.label }}</label>
+            {{ form.correct_answer }}
+            {% if form.correct_answer.help_text %}<p class="hint">{{ form.correct_answer.help_text }}</p>{% endif %}
+            {% if form.correct_answer.errors %}<div class="errorlist">{{ form.correct_answer.errors }}</div>{% endif %}
+          </div>
+        </div>
+
+        <fieldset class="teacher-skillset">
+          <legend>{% trans "Умения" %}</legend>
+          <p class="hint mb-12">{% trans "Выберите умения и при необходимости укажите вес каждого умения." %}</p>
+          {{ skill_formset.management_form }}
+          {% for skill_form in skill_formset %}
+            <div class="teacher-skillset__row">
+              <div class="form-field">
+                <label for="{{ skill_form.skill.id_for_label }}">{{ skill_form.skill.label }}</label>
+                {{ skill_form.skill }}
+                {% if skill_form.skill.errors %}<div class="errorlist">{{ skill_form.skill.errors }}</div>{% endif %}
+              </div>
+              <div class="form-field">
+                <label for="{{ skill_form.weight.id_for_label }}">{{ skill_form.weight.label }}</label>
+                {{ skill_form.weight }}
+                {% if skill_form.weight.help_text %}<p class="hint">{{ skill_form.weight.help_text }}</p>{% endif %}
+                {% if skill_form.weight.errors %}<div class="errorlist">{{ skill_form.weight.errors }}</div>{% endif %}
+              </div>
+              <div class="form-field form-field--delete">
+                <label for="{{ skill_form.DELETE.id_for_label }}">{% trans "Удалить" %}</label>
+                {{ skill_form.DELETE }}
+              </div>
+            </div>
+          {% empty %}
+            <p class="hint">{% trans "Нет доступных полей для умений." %}</p>
+          {% endfor %}
+        </fieldset>
+
+        <div class="form-actions">
+          <button type="submit" class="btn btn-primary">{% trans "Сохранить задачу" %}</button>
+        </div>
+      </form>
+    </section>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a teacher-only "Учительская" tab in the dashboard navigation
- create forms that allow teachers to configure new tasks with metadata and linked skills
- implement the teacher dashboard view and template to render the task creation form and save submitted tasks

## Testing
- python manage.py check
- python manage.py test accounts


------
https://chatgpt.com/codex/tasks/task_e_68ceea5c3758832da4abcda5065a0956