### PR TITLE
Add dynamic skill selection for teacher dashboard

### DIFF
--- a/accounts/templates/accounts/dashboard/teachers.html
+++ b/accounts/templates/accounts/dashboard/teachers.html
@@ -3,9 +3,111 @@
 {% block dashboard_title %}{% if role == 'teacher' %}Мои ученики{% else %}Мои учителя{% endif %}{% endblock %}
 
 {% block dashboard_content %}
-{% if role == 'teacher' %}
-<p>Здесь будет список учеников.</p>
-{% else %}
-<p>Здесь будет список учителей.</p>
-{% endif %}
+  {% if role == 'teacher' %}
+    <form method="post" class="card teacher-skills" aria-describedby="skill-form-description">
+      {% csrf_token %}
+      <h2 class="mb-16">Добавление умений</h2>
+      <p id="skill-form-description" class="muted mb-16">Выберите одно или несколько умений, которые хотите назначить.</p>
+      {% if skills_by_subject %}
+        <div class="skill-fields" data-skill-fields>
+          <div class="skill-field" data-skill-field>
+            <label class="skill-field__label" for="teacher-skill-1">Умение</label>
+            <div class="skill-field__control">
+              <select id="teacher-skill-1" name="skills" class="skill-select">
+                <option value="" selected disabled>Выберите умение</option>
+                {% for subject_block in skills_by_subject %}
+                  <optgroup label="{{ subject_block.subject.name }}">
+                    {% for skill in subject_block.skills %}
+                      <option value="{{ skill.id }}">{{ skill.name }}</option>
+                    {% endfor %}
+                  </optgroup>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="skill-actions">
+          <button type="button" class="skill-add-btn" data-add-skill aria-label="Добавить ещё умение">
+            <span aria-hidden="true">+</span>
+          </button>
+        </div>
+        <div class="skill-submit">
+          <button type="submit" class="btn">Сохранить</button>
+        </div>
+        <template id="skill-field-template">
+          <div class="skill-field" data-skill-field>
+            <label class="skill-field__label">Дополнительное умение</label>
+            <div class="skill-field__control">
+              <select class="skill-select" name="skills">
+                <option value="" selected disabled>Выберите умение</option>
+                {% for subject_block in skills_by_subject %}
+                  <optgroup label="{{ subject_block.subject.name }}">
+                    {% for skill in subject_block.skills %}
+                      <option value="{{ skill.id }}">{{ skill.name }}</option>
+                    {% endfor %}
+                  </optgroup>
+                {% endfor %}
+              </select>
+              <button type="button" class="skill-remove-btn" data-remove-skill aria-label="Удалить умение">
+                <span aria-hidden="true">×</span>
+              </button>
+            </div>
+          </div>
+        </template>
+      {% else %}
+        <p class="hint">Список умений пока пуст.</p>
+      {% endif %}
+    </form>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const container = document.querySelector('[data-skill-fields]');
+        if (!container) return;
+        const addBtn = document.querySelector('[data-add-skill]');
+        const template = document.getElementById('skill-field-template');
+        if (!template) return;
+
+        let counter = container.querySelectorAll('[data-skill-field]').length;
+
+        function createField() {
+          const fragment = template.content.firstElementChild.cloneNode(true);
+          counter += 1;
+          const select = fragment.querySelector('select');
+          const label = fragment.querySelector('label');
+          const id = `teacher-skill-${counter}`;
+          if (select) {
+            select.id = id;
+            select.name = 'skills';
+          }
+          if (label) {
+            label.setAttribute('for', id);
+          }
+          return fragment;
+        }
+
+        addBtn?.addEventListener('click', () => {
+          const field = createField();
+          container.appendChild(field);
+          const lastSelect = container.querySelector('[data-skill-field]:last-of-type select');
+          if (lastSelect) {
+            lastSelect.focus();
+          }
+        });
+
+        container.addEventListener('click', (event) => {
+          const target = event.target instanceof Element ? event.target : null;
+          const removeBtn = target?.closest('[data-remove-skill]');
+          if (!removeBtn) return;
+          const field = removeBtn.closest('[data-skill-field]');
+          if (!field) return;
+          field.remove();
+          const lastSelect = container.querySelector('[data-skill-field]:last-of-type select');
+          if (lastSelect) {
+            lastSelect.focus();
+          }
+        });
+      });
+    </script>
+  {% else %}
+    <p>Здесь будет список учителей.</p>
+  {% endif %}
 {% endblock %}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -331,6 +331,45 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .dashboard-content form h2 { margin-top:0; }
 .dashboard-content label { display:block; margin-bottom:var(--space-xs); }
 .dashboard-content input, .dashboard-content select { width:100%; padding:var(--space-sm); border:1px solid var(--border); border-radius:8px; background:var(--bg); color:var(--text); }
+.teacher-skills { max-width:640px; }
+.skill-fields { display:flex; flex-direction:column; gap:var(--space-sm); }
+.skill-field { display:flex; flex-direction:column; gap:var(--space-xs); }
+.skill-field__control { display:flex; align-items:center; gap:var(--space-xs); }
+.skill-select { flex:1; }
+.skill-add-btn, .skill-remove-btn {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:40px;
+  height:40px;
+  border-radius:999px;
+  border:1px solid var(--accent);
+  background:transparent;
+  color:var(--accent);
+  font-size:1.5rem;
+  cursor:pointer;
+  transition:transform 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+.skill-add-btn:hover,
+.skill-add-btn:focus-visible,
+.skill-remove-btn:hover,
+.skill-remove-btn:focus-visible {
+  background:color-mix(in srgb, var(--accent) 15%, transparent);
+  color:color-mix(in srgb, var(--accent) 80%, black);
+  transform:translateY(-1px);
+  outline:none;
+}
+.skill-remove-btn {
+  border-color:var(--border);
+  color:var(--muted);
+  font-size:1.25rem;
+}
+.skill-remove-btn:hover,
+.skill-remove-btn:focus-visible {
+  border-color:color-mix(in srgb, var(--accent) 30%, var(--border));
+}
+.skill-actions { margin:var(--space-sm) 0; }
+.skill-submit { margin-top:var(--space-md); }
 .role-toggle { display:flex; gap:var(--space-sm); }
 .role-toggle input { display:none; }
 .role-toggle label { flex:1; text-align:center; padding:10px 0; border:1px solid var(--border); border-radius:10px; background:var(--card); cursor:pointer; }


### PR DESCRIPTION
## Summary
- provide grouped skill options to the teacher dashboard context
- render a dynamic skill selection form with add/remove controls for teachers
- style the teacher skills form for the new interactive controls

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cef32d2cac832d853e057833bf5695