### PR TITLE
Make teacher skill selection dynamic

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -234,7 +234,7 @@ class TaskSkillForm(forms.Form):
         return cleaned_data
 
 
-TaskSkillFormSet = formset_factory(TaskSkillForm, extra=3, can_delete=True)
+TaskSkillFormSet = formset_factory(TaskSkillForm, extra=1, can_delete=True)
 
 
 def build_task_skill_formset(*, subject: Subject | None, data=None, prefix: str = "skills"):
@@ -243,4 +243,5 @@ def build_task_skill_formset(*, subject: Subject | None, data=None, prefix: str 
     formset = TaskSkillFormSet(data=data, prefix=prefix)
     for form in formset.forms:
         form.set_subject(subject)
+    formset.empty_form.set_subject(subject)
     return formset

--- a/accounts/templates/accounts/dashboard/teachers.html
+++ b/accounts/templates/accounts/dashboard/teachers.html
@@ -67,31 +67,65 @@
           </div>
         </div>
 
-        <fieldset class="teacher-skillset">
+        <fieldset class="teacher-skillset" data-formset-prefix="{{ skill_formset.prefix }}">
           <legend>{% trans "Умения" %}</legend>
           <p class="hint mb-12">{% trans "Выберите умения и при необходимости укажите вес каждого умения." %}</p>
           {{ skill_formset.management_form }}
-          {% for skill_form in skill_formset %}
-            <div class="teacher-skillset__row">
-              <div class="form-field">
-                <label for="{{ skill_form.skill.id_for_label }}">{{ skill_form.skill.label }}</label>
-                {{ skill_form.skill }}
-                {% if skill_form.skill.errors %}<div class="errorlist">{{ skill_form.skill.errors }}</div>{% endif %}
+          <div class="teacher-skillset__rows" data-formset-container>
+            {% for skill_form in skill_formset %}
+              <div class="teacher-skillset__row" data-formset-form>
+                {{ skill_form.non_field_errors }}
+                <div class="form-field">
+                  <label for="{{ skill_form.skill.id_for_label }}">{{ skill_form.skill.label }}</label>
+                  {{ skill_form.skill }}
+                  {% if skill_form.skill.errors %}<div class="errorlist">{{ skill_form.skill.errors }}</div>{% endif %}
+                </div>
+                <div class="form-field teacher-skillset__weight">
+                  <label for="{{ skill_form.weight.id_for_label }}">{{ skill_form.weight.label }}</label>
+                  {{ skill_form.weight }}
+                  {% if skill_form.weight.help_text %}<p class="hint">{{ skill_form.weight.help_text }}</p>{% endif %}
+                  {% if skill_form.weight.errors %}<div class="errorlist">{{ skill_form.weight.errors }}</div>{% endif %}
+                </div>
+                <div class="teacher-skillset__controls">
+                  <button type="button" class="teacher-skillset__remove" data-formset-delete aria-label="{% trans 'Удалить умение' %}">
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                  <div class="teacher-skillset__delete">
+                    {{ skill_form.DELETE }}
+                  </div>
+                </div>
               </div>
+            {% empty %}
+              <p class="hint">{% trans "Нет доступных полей для умений." %}</p>
+            {% endfor %}
+          </div>
+          <template data-formset-empty>
+            <div class="teacher-skillset__row" data-formset-form>
               <div class="form-field">
-                <label for="{{ skill_form.weight.id_for_label }}">{{ skill_form.weight.label }}</label>
-                {{ skill_form.weight }}
-                {% if skill_form.weight.help_text %}<p class="hint">{{ skill_form.weight.help_text }}</p>{% endif %}
-                {% if skill_form.weight.errors %}<div class="errorlist">{{ skill_form.weight.errors }}</div>{% endif %}
+                <label for="{{ skill_formset.empty_form.skill.id_for_label }}">{{ skill_formset.empty_form.skill.label }}</label>
+                {{ skill_formset.empty_form.skill }}
               </div>
-              <div class="form-field form-field--delete">
-                <label for="{{ skill_form.DELETE.id_for_label }}">{% trans "Удалить" %}</label>
-                {{ skill_form.DELETE }}
+              <div class="form-field teacher-skillset__weight">
+                <label for="{{ skill_formset.empty_form.weight.id_for_label }}">{{ skill_formset.empty_form.weight.label }}</label>
+                {{ skill_formset.empty_form.weight }}
+                {% if skill_formset.empty_form.weight.help_text %}<p class="hint">{{ skill_formset.empty_form.weight.help_text }}</p>{% endif %}
+              </div>
+              <div class="teacher-skillset__controls">
+                <button type="button" class="teacher-skillset__remove" data-formset-delete aria-label="{% trans 'Удалить умение' %}">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+                <div class="teacher-skillset__delete">
+                  {{ skill_formset.empty_form.DELETE }}
+                </div>
               </div>
             </div>
-          {% empty %}
-            <p class="hint">{% trans "Нет доступных полей для умений." %}</p>
-          {% endfor %}
+          </template>
+          <div class="teacher-skillset__footer">
+            <button type="button" class="btn-icon" data-formset-add>
+              <span aria-hidden="true">+</span>
+              <span class="sr-only">{% trans "Добавить умение" %}</span>
+            </button>
+          </div>
         </fieldset>
 
         <div class="form-actions">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -337,6 +337,123 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .role-toggle input:checked + label { background:var(--accent); color:#001420; border-color:color-mix(in srgb, var(--accent) 70%, black); }
 
 
+.teacher-skillset {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: var(--space-lg);
+  margin-top: var(--space-xl);
+  background: color-mix(in srgb, var(--card) 85%, transparent);
+}
+
+.teacher-skillset legend {
+  font-weight: 600;
+  padding: 0 var(--space-sm);
+}
+
+.teacher-skillset__rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.teacher-skillset__row {
+  display: grid;
+  gap: var(--space-md);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 160px) auto;
+  align-items: end;
+  padding: var(--space-md);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg);
+}
+
+.teacher-skillset__row--hidden {
+  display: none;
+}
+
+.teacher-skillset__weight input {
+  text-align: right;
+}
+
+.teacher-skillset__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  justify-content: flex-end;
+}
+
+.teacher-skillset__remove {
+  border: none;
+  background: none;
+  color: var(--muted);
+  font-size: 28px;
+  line-height: 1;
+  padding: 4px;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.teacher-skillset__remove:hover:not(:disabled) {
+  color: var(--accent);
+}
+
+.teacher-skillset__remove:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.teacher-skillset__delete {
+  display: none;
+}
+
+.teacher-skillset__footer {
+  margin-top: var(--space-md);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn-icon {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  border: 1px dashed var(--border);
+  background: transparent;
+  color: var(--muted);
+  font-size: 24px;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.btn-icon:hover {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 65%, var(--border));
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.btn-icon:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.btn-icon:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+@media (max-width: 720px) {
+  .teacher-skillset__row {
+    grid-template-columns: 1fr;
+  }
+
+  .teacher-skillset__controls {
+    justify-content: flex-start;
+  }
+}
+
+
 /* Utility */
 .sr { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -101,6 +101,93 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
+document.addEventListener('DOMContentLoaded', () => {
+  const fieldset = document.querySelector('.teacher-skillset[data-formset-prefix]');
+  if (!fieldset) return;
+
+  const prefix = fieldset.dataset.formsetPrefix;
+  const container = fieldset.querySelector('[data-formset-container]');
+  const addBtn = fieldset.querySelector('[data-formset-add]');
+  const template = fieldset.querySelector('[data-formset-empty]');
+  const totalFormsInput = fieldset.querySelector(`input[name="${prefix}-TOTAL_FORMS"]`);
+
+  if (!container || !addBtn || !template || !totalFormsInput) return;
+
+  const getForms = () => Array.from(container.querySelectorAll('[data-formset-form]'));
+
+  const getActiveForms = () =>
+    getForms().filter((formEl) => !formEl.classList.contains('teacher-skillset__row--hidden'));
+
+  const updateDeleteButtonsState = () => {
+    const activeForms = getActiveForms();
+    activeForms.forEach((formEl, index) => {
+      const btn = formEl.querySelector('[data-formset-delete]');
+      if (!btn) return;
+      btn.disabled = activeForms.length === 1 && index === 0;
+    });
+  };
+
+  const hideForm = (formEl) => {
+    const deleteInput = formEl.querySelector('input[name$="-DELETE"]');
+    if (deleteInput) {
+      deleteInput.checked = true;
+    }
+    formEl.classList.add('teacher-skillset__row--hidden');
+    updateDeleteButtonsState();
+  };
+
+  const registerForm = (formEl) => {
+    const deleteInput = formEl.querySelector('input[name$="-DELETE"]');
+    const deleteBtn = formEl.querySelector('[data-formset-delete]');
+
+    if (deleteInput && deleteInput.checked) {
+      formEl.classList.add('teacher-skillset__row--hidden');
+    }
+
+    if (deleteBtn && deleteInput) {
+      deleteBtn.addEventListener('click', () => {
+        if (deleteBtn.disabled) return;
+        hideForm(formEl);
+      });
+    }
+  };
+
+  getForms().forEach((form) => registerForm(form));
+  updateDeleteButtonsState();
+
+  const buildFormElement = (index) => {
+    const templateForm = template.content
+      ? template.content.firstElementChild
+      : template.firstElementChild;
+    if (!templateForm) return null;
+
+    const html = templateForm.outerHTML.replace(/__prefix__/g, index);
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = html.trim();
+    const formEl = wrapper.firstElementChild;
+    if (!formEl) return null;
+
+    const deleteInput = formEl.querySelector('input[name$="-DELETE"]');
+    if (deleteInput) {
+      deleteInput.checked = false;
+    }
+
+    return formEl;
+  };
+
+  addBtn.addEventListener('click', () => {
+    const totalForms = parseInt(totalFormsInput.value, 10) || 0;
+    const formEl = buildFormElement(totalForms);
+    if (!formEl) return;
+
+    container.appendChild(formEl);
+    totalFormsInput.value = String(totalForms + 1);
+    registerForm(formEl);
+    formEl.classList.remove('teacher-skillset__row--hidden');
+    updateDeleteButtonsState();
+  });
+});
+
 if (typeof module !== 'undefined') {
   module.exports = { updatePrice };
 }


### PR DESCRIPTION
## Summary
- add dynamic skill formset controls in the teacher dashboard so additional skills can be added or removed on demand
- style the teacher skill fieldset with dedicated controls and icon buttons
- initialize empty form querysets for the dynamic formset items

## Testing
- python manage.py check *(fails: missing Pillow dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cef4f77780832db4e628065026eff5