### PR TITLE
Add layered matrix-style background

### DIFF
--- a/static/css/cyber.css
+++ b/static/css/cyber.css
@@ -2,6 +2,7 @@
 
 :root{
   --bg:#0a0f0d;           /* глубокий тёмный */
+  --grid:#062b1e;         /* линии сетки */
   --panel:#0f1613;        /* тёмная панель */
   --muted:#8aa39b;        /* приглушённый текст */
   --text:#e6fff5;         /* основной текст */
@@ -16,7 +17,13 @@ html,body{height:100%;}
 body{
   margin:0;
   font: 16px/1.5 'JetBrains Mono', Consolas, Menlo, Monaco, 'SFMono-Regular', monospace;
-  background: radial-gradient(1200px 600px at 10% 0%, #0b1310 0%, var(--bg) 45%) fixed;
+  background:
+    radial-gradient(1200px 600px at 10% 100%, #00140c 0%, transparent 70%),
+    radial-gradient(1200px 600px at 90% 0%, #00140c 0%, transparent 70%),
+    linear-gradient(transparent 23px, var(--grid) 24px),
+    linear-gradient(90deg, transparent 23px, var(--grid) 24px),
+    var(--bg);
+  background-size: auto, auto, 24px 24px, 24px 24px, auto;
   color:var(--text);
 }
 header{


### PR DESCRIPTION
## Summary
- add a reusable CSS variable for the matrix-style grid lines
- layer multiple gradients on the body to reproduce the matrix-inspired background behind all content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d39d44b938832da121530ccda9cc4e