### PR TITLE
Remove background gradient from cyber theme

### DIFF
--- a/static/css/cyber.css
+++ b/static/css/cyber.css
@@ -18,12 +18,10 @@ body{
   margin:0;
   font: 16px/1.5 'JetBrains Mono', Consolas, Menlo, Monaco, 'SFMono-Regular', monospace;
   background:
-    radial-gradient(1200px 600px at 10% 100%, #00140c 0%, transparent 70%),
-    radial-gradient(1200px 600px at 90% 0%, #00140c 0%, transparent 70%),
     linear-gradient(transparent 23px, var(--grid) 24px),
     linear-gradient(90deg, transparent 23px, var(--grid) 24px),
     var(--bg);
-  background-size: auto, auto, 24px 24px, 24px 24px, auto;
+  background-size: 24px 24px, 24px 24px, auto;
   color:var(--text);
 }
 header{


### PR DESCRIPTION
## Summary
- remove the body background radial gradients from the cyber theme stylesheet so that only the grid remains
- adjust the related background-size declaration to match the simplified background layers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3a50b8240832d941b8a09d1bb46a4