### PR TITLE
Display enrolled courses in dashboard courses tab

### DIFF
--- a/accounts/templates/accounts/dashboard/courses.html
+++ b/accounts/templates/accounts/dashboard/courses.html
@@ -1,7 +1,51 @@
 {% extends 'accounts/dashboard/base.html' %}
+{% load i18n %}
 
-{% block dashboard_title %}Курсы{% endblock %}
+{% block dashboard_title %}{% trans "Курсы" %}{% endblock %}
 
 {% block dashboard_content %}
-<p>Здесь будут мои курсы.</p>
+  {% if enrollments %}
+    <div class="courses-grid" role="list">
+      {% for enrollment in enrollments %}
+        {% with course=enrollment.course %}
+          <article class="card course-card" role="listitem">
+            {% if course.cover_image %}
+              <img class="course-card__image" src="{{ course.cover_image.url }}" alt="{{ course.title }}" loading="lazy">
+            {% endif %}
+            <header class="course-card__header">
+              <h3 class="course-card__title">{{ course.title }}</h3>
+              <span class="course-card__status" aria-label="{% trans 'Статус обучения' %}">
+                {{ enrollment.get_status_display }}
+              </span>
+            </header>
+            {% if course.subtitle %}
+              <p class="course-card__subtitle">{{ course.subtitle }}</p>
+            {% elif course.short_description %}
+              <p class="course-card__subtitle">{{ course.short_description }}</p>
+            {% endif %}
+            <dl class="course-card__meta">
+              {% if course.duration_weeks %}
+                <div>
+                  <dt>{% trans "Длительность" %}</dt>
+                  <dd>{% blocktrans with weeks=course.duration_weeks %}{{ weeks }} нед.{% endblocktrans %}</dd>
+                </div>
+              {% endif %}
+              <div>
+                <dt>{% trans "Язык" %}</dt>
+                <dd>{{ course.get_language_display }}</dd>
+              </div>
+            </dl>
+            <div class="course-card__progress" role="progressbar" aria-valuenow="{{ enrollment.progress|floatformat:'-2' }}" aria-valuemin="0" aria-valuemax="100">
+              <span class="course-card__progress-bar" style="width: {{ enrollment.progress|floatformat:'-2' }}%;"></span>
+            </div>
+            <p class="course-card__progress-label">
+              {% blocktrans with progress=enrollment.progress|floatformat:'-1' %}Прогресс: {{ progress }}%{% endblocktrans %}
+            </p>
+          </article>
+        {% endwith %}
+      {% endfor %}
+    </div>
+  {% else %}
+    <p class="muted">{% trans "Вы ещё не записаны ни на один курс." %}</p>
+  {% endif %}
 {% endblock %}

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -489,10 +489,19 @@ def dashboard_subjects(request):
 
 @login_required
 def dashboard_courses(request):
-    """Display a placeholder courses dashboard."""
+    """Display all courses the current user is enrolled in."""
 
     role = _get_dashboard_role(request)
-    context = {"active_tab": "courses", "role": role}
+
+    enrollments = (
+        request.user.course_enrollments.select_related("course").order_by("-enrolled_at")
+    )
+
+    context = {
+        "active_tab": "courses",
+        "role": role,
+        "enrollments": enrollments,
+    }
     return render(request, "accounts/dashboard/courses.html", context)
 
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -204,6 +204,97 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
   box-shadow: 0 0 14px color-mix(in srgb, var(--accent) 25%, transparent);
 }
 
+.courses-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--space-md);
+}
+
+.course-card {
+  grid-template-rows: auto;
+  gap: var(--space-sm);
+}
+
+.course-card__image {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.course-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.course-card__title {
+  margin: 0;
+  font-size: var(--font-lg);
+  line-height: 1.2;
+}
+
+.course-card__status {
+  font-size: var(--font-sm);
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 22%, #0b1017);
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.course-card__subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.course-card__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-sm);
+  margin: 0;
+}
+
+.course-card__meta div {
+  display: grid;
+  gap: 4px;
+}
+
+.course-card__meta dt {
+  font-size: var(--font-sm);
+  color: var(--muted);
+  margin: 0;
+}
+
+.course-card__meta dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.course-card__progress {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 18%, #0b1017);
+  overflow: hidden;
+}
+
+.course-card__progress-bar {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  border-radius: inherit;
+}
+
+.course-card__progress-label {
+  margin: 0;
+  font-size: var(--font-sm);
+  color: var(--muted);
+}
+
 /* Custom checkbox inside pill */
 .pill-check .tick {
   width: 18px;


### PR DESCRIPTION
## Summary
- load student course enrollments in the dashboard courses view
- render each enrollment as a detailed course card in the courses tab
- add dashboard styles for the new course grid, status, and progress display

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d4e7df0e48832db0f60ebb4bc68476