### PR TITLE
Add interactive course graph to course dashboard

### DIFF
--- a/accounts/templates/accounts/dashboard/courses.html
+++ b/accounts/templates/accounts/dashboard/courses.html
@@ -1,5 +1,5 @@
 {% extends 'accounts/dashboard/base.html' %}
-{% load i18n %}
+{% load i18n static %}
 
 {% block dashboard_title %}{% trans "Курсы" %}{% endblock %}
 
@@ -35,12 +35,58 @@
                 <dd>{{ course.get_language_display }}</dd>
               </div>
             </dl>
-            <div class="course-card__progress" role="progressbar" aria-valuenow="{{ enrollment.progress|floatformat:'-2' }}" aria-valuemin="0" aria-valuemax="100">
-              <span class="course-card__progress-bar" style="width: {{ enrollment.progress|floatformat:'-2' }}%;"></span>
+            <div class="course-card__graph" data-course-graph-wrapper>
+              <div
+                class="course-graph"
+                data-course-graph
+                data-course-id="{{ course.id }}"
+                data-enrollment-id="{{ enrollment.id }}"
+                aria-label="{% trans 'Граф модулей курса' %}"
+              >
+                <svg class="course-graph__edges" role="presentation" aria-hidden="true"></svg>
+                <div class="course-graph__nodes">
+                  {% for node in enrollment.graph.nodes %}
+                    <button
+                      type="button"
+                      class="course-graph__node {% if node.locked %}course-graph__node--locked{% else %}course-graph__node--active{% endif %}"
+                      data-node
+                      data-node-id="{{ node.id }}"
+                      data-kind="{{ node.kind }}"
+                      data-locked="{{ node.locked|yesno:'true,false' }}"
+                      data-url="{{ node.url }}"
+                      style="--graph-col: {{ node.col }}; --graph-row: {{ node.row }}; --graph-offset-x: {{ node.dx }}px; --graph-offset-y: {{ node.dy }}px; --graph-progress: {{ node.progress|floatformat:'-2' }}%;"
+                      {% if node.locked %}disabled{% endif %}
+                      aria-pressed="false"
+                    >
+                      <span class="course-graph__ring" aria-hidden="true">
+                        <span class="course-graph__ring-progress"></span>
+                        <span class="course-graph__ring-label">{{ node.progress|floatformat:'-1' }}%</span>
+                      </span>
+                      <span class="course-graph__node-content">
+                        <span class="course-graph__node-title">{{ node.title }}</span>
+                        {% if node.subtitle %}
+                          <span class="course-graph__node-subtitle">{{ node.subtitle }}</span>
+                        {% endif %}
+                      </span>
+                    </button>
+                  {% empty %}
+                    <p class="course-graph__empty">{% trans "В этом курсе пока нет модулей." %}</p>
+                  {% endfor %}
+                </div>
+                <div class="course-graph__edges-data" hidden aria-hidden="true">
+                  {% for edge in enrollment.graph.edges %}
+                    <span
+                      data-edge
+                      data-edge-id="{{ edge.id }}"
+                      data-src="{{ edge.src }}"
+                      data-dst="{{ edge.dst }}"
+                      data-kind="{{ edge.kind }}"
+                      data-locked="{{ edge.locked|yesno:'true,false' }}"
+                    ></span>
+                  {% endfor %}
+                </div>
+              </div>
             </div>
-            <p class="course-card__progress-label">
-              {% blocktrans with progress=enrollment.progress|floatformat:'-1' %}Прогресс: {{ progress }}%{% endblocktrans %}
-            </p>
           </article>
         {% endwith %}
       {% endfor %}
@@ -48,4 +94,5 @@
   {% else %}
     <p class="muted">{% trans "Вы ещё не записаны ни на один курс." %}</p>
   {% endif %}
+  <script type="module" src="{% static 'js/course-graph.js' %}"></script>
 {% endblock %}

--- a/courses/models.py
+++ b/courses/models.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
+from django.urls import reverse
 
 
 class TimeStampedModel(models.Model):
@@ -220,6 +221,12 @@ class CourseModule(TimeStampedModel):
 
     def __str__(self) -> str:
         return f"{self.course}: {self.title}"
+
+    def get_absolute_url(self) -> str:
+        return reverse(
+            "courses:module-detail",
+            kwargs={"course_slug": self.course.slug, "module_slug": self.slug},
+        )
 
 
 class CourseGraphEdge(TimeStampedModel):

--- a/courses/templates/courses/module_detail.html
+++ b/courses/templates/courses/module_detail.html
@@ -1,0 +1,78 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %}{{ module.title }} — {{ course.title }}{% endblock %}
+
+{% block content %}
+  <div class="container module-detail">
+    <nav class="module-detail__breadcrumbs" aria-label="{% trans 'Навигация по курсу' %}">
+      <a class="module-detail__breadcrumb" href="{% url 'accounts:dashboard-courses' %}">{% trans 'Курсы' %}</a>
+      <span aria-hidden="true">/</span>
+      <a class="module-detail__breadcrumb" href="{% url 'accounts:dashboard-courses' %}?course={{ course.slug }}">{{ course.title }}</a>
+      <span aria-hidden="true">/</span>
+      <span class="module-detail__breadcrumb module-detail__breadcrumb--current">{{ module.title }}</span>
+    </nav>
+
+    <header class="module-detail__header">
+      <h2 class="module-detail__title">{{ module.title }}</h2>
+      {% if module.subtitle %}
+        <p class="module-detail__subtitle">{{ module.subtitle }}</p>
+      {% endif %}
+    </header>
+
+    {% if module.description %}
+      <div class="module-detail__description">{{ module.description|linebreaks }}</div>
+    {% endif %}
+
+    {% if incoming_edges or outgoing_edges %}
+      <section class="module-detail__relations" aria-label="{% trans 'Связи модуля' %}">
+        {% if incoming_edges %}
+          <div>
+            <h3>{% trans 'Требуется перед' %}</h3>
+            <ul>
+              {% for edge in incoming_edges %}
+                <li>{{ edge.src.title }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+        {% if outgoing_edges %}
+          <div>
+            <h3>{% trans 'Открывает путь к' %}</h3>
+            <ul>
+              {% for edge in outgoing_edges %}
+                <li>{{ edge.dst.title }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      </section>
+    {% endif %}
+
+    {% if items %}
+      <section class="module-detail__items" aria-label="{% trans 'Содержимое модуля' %}">
+        <h3>{% trans 'Элементы модуля' %}</h3>
+        <ol>
+          {% for item in items %}
+            <li>
+              <strong>
+                {% if item.kind == item.ItemKind.THEORY %}
+                  {% trans 'Теория' %}
+                {% elif item.kind == item.ItemKind.TASK %}
+                  {% trans 'Задание' %}
+                {% else %}
+                  {{ item.get_kind_display }}
+                {% endif %}
+              </strong>
+              {% if item.theory_card %}
+                — {{ item.theory_card.title }}
+              {% elif item.task %}
+                — {{ item.task.name|default:item.task.pk }}
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ol>
+      </section>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import views
+
+app_name = "courses"
+
+urlpatterns = [
+    path("<slug:course_slug>/<slug:module_slug>/", views.module_detail, name="module-detail"),
+]

--- a/courses/views.py
+++ b/courses/views.py
@@ -1,3 +1,46 @@
-from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+from django.db.models import Prefetch
+from django.shortcuts import get_object_or_404, render
 
-# Create your views here.
+from .models import Course, CourseGraphEdge, CourseModule, CourseModuleItem
+
+
+@login_required
+def module_detail(request, course_slug: str, module_slug: str):
+    course = get_object_or_404(
+        Course.objects.prefetch_related(
+            Prefetch(
+                "modules",
+                queryset=CourseModule.objects.order_by("rank", "col", "id"),
+            ),
+            Prefetch(
+                "graph_edges",
+                queryset=CourseGraphEdge.objects.select_related("src", "dst"),
+            ),
+        ),
+        slug=course_slug,
+        is_active=True,
+    )
+
+    module = get_object_or_404(
+        course.modules.prefetch_related(
+            Prefetch(
+                "items",
+                queryset=CourseModuleItem.objects.select_related("theory_card", "task")
+                .order_by("position", "id"),
+            ),
+        ),
+        slug=module_slug,
+    )
+
+    incoming = [edge for edge in course.graph_edges.all() if edge.dst_id == module.id]
+    outgoing = [edge for edge in course.graph_edges.all() if edge.src_id == module.id]
+
+    context = {
+        "course": course,
+        "module": module,
+        "items": list(module.items.all()),
+        "incoming_edges": incoming,
+        "outgoing_edges": outgoing,
+    }
+    return render(request, "courses/module_detail.html", context)

--- a/fractalschool/urls.py
+++ b/fractalschool/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path('', HomeView.as_view(), name='home'),
     path('admin/', admin.site.urls),
     path('accounts/', include('accounts.urls')),
+    path('courses/', include(('courses.urls', 'courses'), namespace='courses')),
     path('applications/', include(('applications.urls', 'applications'), namespace='applications')),
 
     path('', include('apps.recsys.api.urls')),

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -198,6 +198,254 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 }
 /* Exams selection UX */
 .formats .pill input { margin: 0; }
+
+/* Course graph component */
+.course-card__graph {
+  margin-top: var(--space-lg);
+}
+
+.course-graph {
+  position: relative;
+  --course-graph-column-width: 200px;
+  --course-graph-row-height: 160px;
+  --course-graph-gradient-start: rgba(0, 255, 156, 0.9);
+  --course-graph-gradient-end: rgba(156, 107, 255, 0.85);
+  --course-graph-muted: rgba(255, 255, 255, 0.12);
+  --course-graph-panel: rgba(12, 18, 27, 0.88);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(12, 18, 27, 0.8), rgba(9, 13, 19, 0.9));
+  padding: 32px 24px;
+  overflow: hidden;
+}
+
+.course-graph__nodes {
+  position: relative;
+  min-height: 240px;
+}
+
+.course-graph__node {
+  position: absolute;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  background: color-mix(in srgb, var(--course-graph-panel) 85%, transparent);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.3s ease, opacity 0.25s ease;
+  left: calc(var(--graph-col, 0) * var(--course-graph-column-width) + var(--graph-offset-x, 0px));
+  top: calc(var(--graph-row, 0) * var(--course-graph-row-height) + var(--graph-offset-y, 0px));
+  transform: translate(-50%, -50%);
+  width: 180px;
+  color: var(--text);
+  text-align: center;
+}
+
+.course-graph__node:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.course-graph__node--active:hover {
+  transform: translate(-50%, -50%) scale(1.04);
+  border-color: color-mix(in srgb, var(--accent) 70%, transparent);
+  box-shadow: 0 12px 36px rgba(0, 255, 156, 0.28);
+}
+
+.course-graph__node--locked {
+  opacity: 0.45;
+  cursor: default;
+  box-shadow: none;
+}
+
+.course-graph__node--locked .course-graph__ring-progress {
+  filter: grayscale(1);
+  opacity: 0.4;
+}
+
+.course-graph__node--highlighted {
+  border-color: color-mix(in srgb, var(--accent) 60%, transparent);
+  box-shadow: 0 0 24px rgba(156, 107, 255, 0.45);
+}
+
+.course-graph__node--just-unlocked {
+  animation: course-graph-pop 0.5s ease;
+}
+
+@keyframes course-graph-pop {
+  0% {
+    transform: translate(-50%, -50%) scale(0.8);
+    opacity: 0;
+  }
+  60% {
+    transform: translate(-50%, -50%) scale(1.08);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+.course-graph__ring {
+  position: relative;
+  width: 96px;
+  height: 96px;
+  display: grid;
+  place-items: center;
+}
+
+.course-graph__ring::after {
+  content: "";
+  position: absolute;
+  inset: 14px;
+  border-radius: 50%;
+  background: rgba(10, 15, 22, 0.92);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.55);
+}
+
+.course-graph__ring-progress {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    conic-gradient(
+      from -90deg,
+      var(--course-graph-gradient-start) 0 var(--graph-progress, 0%),
+      rgba(255, 255, 255, 0.08) var(--graph-progress, 0%) 100%
+    );
+}
+
+.course-graph__ring-label {
+  position: relative;
+  z-index: 1;
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: 0.4px;
+}
+
+.course-graph__node-title {
+  font-weight: 700;
+  font-size: 16px;
+  display: block;
+}
+
+.course-graph__node-subtitle {
+  display: block;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.course-graph__edges {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  stroke-linecap: round;
+}
+
+.course-graph__edge-line {
+  stroke: rgba(0, 255, 156, 0.75);
+  stroke-width: 4;
+  opacity: 0.75;
+  filter: drop-shadow(0 0 10px rgba(0, 255, 156, 0.35));
+  transition: opacity 0.2s ease;
+}
+
+.course-graph__edge-line--locked {
+  stroke: rgba(255, 255, 255, 0.2);
+  opacity: 0.35;
+  stroke-dasharray: 10 12;
+  filter: none;
+}
+
+.course-graph__edge-line--highlighted {
+  opacity: 1;
+  filter: drop-shadow(0 0 12px rgba(156, 107, 255, 0.55));
+}
+
+.course-graph__empty {
+  margin: 0;
+  text-align: center;
+  color: var(--muted);
+}
+
+@media (max-width: 1024px) {
+  .course-graph {
+    --course-graph-column-width: 160px;
+    --course-graph-row-height: 140px;
+  }
+
+  .course-graph__node {
+    width: 160px;
+  }
+}
+
+@media (max-width: 720px) {
+  .course-graph {
+    padding: 24px 18px;
+    --course-graph-column-width: 140px;
+    --course-graph-row-height: 120px;
+  }
+
+  .course-graph__node {
+    width: 150px;
+    padding: 14px;
+  }
+}
+
+.module-detail__breadcrumbs {
+  display: flex;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted);
+  margin-bottom: var(--space-md);
+}
+
+.module-detail__breadcrumb {
+  color: var(--accent);
+}
+
+.module-detail__breadcrumb--current {
+  color: var(--text);
+}
+
+.module-detail__header {
+  margin-bottom: var(--space-lg);
+}
+
+.module-detail__title {
+  margin: 0 0 var(--space-sm);
+}
+
+.module-detail__subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.module-detail__description {
+  background: rgba(10, 15, 22, 0.9);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  margin-bottom: var(--space-lg);
+}
+
+.module-detail__relations {
+  display: grid;
+  gap: var(--space-lg);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: var(--space-lg);
+}
+
+.module-detail__items ol {
+  padding-left: 1.2em;
+}
 .formats .pill:has(input:checked) {
   background: color-mix(in srgb, var(--accent) 22%, #0b1017);
   border-color: color-mix(in srgb, var(--accent) 65%, var(--border));

--- a/static/js/course-graph.js
+++ b/static/js/course-graph.js
@@ -1,0 +1,202 @@
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+const gradientStops = [
+  { offset: '0%', color: 'rgba(0,255,156,0.9)' },
+  { offset: '100%', color: 'rgba(156,107,255,0.85)' },
+];
+
+function createGradient(svg, id) {
+  const defs = svg.querySelector('defs') || document.createElementNS(SVG_NS, 'defs');
+  const gradient = document.createElementNS(SVG_NS, 'linearGradient');
+  gradient.setAttribute('id', id);
+  gradient.setAttribute('gradientUnits', 'userSpaceOnUse');
+  gradientStops.forEach(({ offset, color }) => {
+    const stop = document.createElementNS(SVG_NS, 'stop');
+    stop.setAttribute('offset', offset);
+    stop.setAttribute('stop-color', color);
+    gradient.appendChild(stop);
+  });
+  defs.appendChild(gradient);
+  if (!defs.parentNode) {
+    svg.appendChild(defs);
+  }
+  return gradient;
+}
+
+function updateGradientDirection(gradient, x1, y1, x2, y2) {
+  gradient.setAttribute('x1', String(x1));
+  gradient.setAttribute('y1', String(y1));
+  gradient.setAttribute('x2', String(x2));
+  gradient.setAttribute('y2', String(y2));
+}
+
+function initGraph(graphEl) {
+  if (!graphEl || graphEl.dataset.graphReady === 'true') {
+    return;
+  }
+
+  const svg = graphEl.querySelector('.course-graph__edges');
+  const hiddenEdges = Array.from(graphEl.querySelectorAll('[data-edge]'));
+  const nodeElements = Array.from(graphEl.querySelectorAll('[data-node]'));
+
+  if (!svg || nodeElements.length === 0) {
+    graphEl.dataset.graphReady = 'true';
+    return;
+  }
+
+  svg.textContent = '';
+  const uuid = (window.crypto && typeof window.crypto.randomUUID === 'function')
+    ? window.crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
+  const baseGradientId = `course-graph-gradient-${graphEl.dataset.courseId || uuid}`;
+
+  const nodeMap = new Map();
+  nodeElements.forEach((node) => {
+    nodeMap.set(node.dataset.nodeId, node);
+  });
+
+  const edgeGradients = new Map();
+  const edgeElements = hiddenEdges.map((edgeData, index) => {
+    const line = document.createElementNS(SVG_NS, 'line');
+    line.classList.add('course-graph__edge-line');
+    if (edgeData.dataset.locked === 'true') {
+      line.classList.add('course-graph__edge-line--locked');
+      line.removeAttribute('stroke');
+    } else {
+      const gradientId = `${baseGradientId}-${index}`;
+      const gradient = createGradient(svg, gradientId);
+      edgeGradients.set(line, gradient);
+      line.setAttribute('stroke', `url(#${gradientId})`);
+    }
+    line.dataset.edgeId = edgeData.dataset.edgeId || '';
+    line.dataset.src = edgeData.dataset.src || '';
+    line.dataset.dst = edgeData.dataset.dst || '';
+    line.dataset.locked = edgeData.dataset.locked || 'false';
+    svg.appendChild(line);
+    return line;
+  });
+
+  const updateEdges = () => {
+    const rect = graphEl.getBoundingClientRect();
+    const width = Math.max(rect.width, 1);
+    const height = Math.max(rect.height, 1);
+
+    svg.setAttribute('width', String(width));
+    svg.setAttribute('height', String(height));
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+
+    edgeElements.forEach((line) => {
+      const srcNode = nodeMap.get(line.dataset.src);
+      const dstNode = nodeMap.get(line.dataset.dst);
+      if (!srcNode || !dstNode) {
+        line.setAttribute('opacity', '0');
+        return;
+      }
+
+      const srcRect = srcNode.getBoundingClientRect();
+      const dstRect = dstNode.getBoundingClientRect();
+
+      const x1 = srcRect.left + srcRect.width / 2 - rect.left;
+      const y1 = srcRect.top + srcRect.height / 2 - rect.top;
+      const x2 = dstRect.left + dstRect.width / 2 - rect.left;
+      const y2 = dstRect.top + dstRect.height / 2 - rect.top;
+
+      line.setAttribute('x1', String(x1));
+      line.setAttribute('y1', String(y1));
+      line.setAttribute('x2', String(x2));
+      line.setAttribute('y2', String(y2));
+      line.setAttribute('opacity', line.dataset.locked === 'true' ? '0.4' : '0.85');
+
+      const gradient = edgeGradients.get(line);
+      if (gradient && line.dataset.locked !== 'true') {
+        updateGradientDirection(gradient, x1, y1, x2, y2);
+      }
+    });
+  };
+
+  const highlightConnected = (nodeId, active) => {
+    edgeElements.forEach((line) => {
+      if (line.dataset.locked === 'true') {
+        return;
+      }
+      const connects = line.dataset.src === nodeId || line.dataset.dst === nodeId;
+      if (connects) {
+        line.classList.toggle('course-graph__edge-line--highlighted', active);
+        const otherId = line.dataset.src === nodeId ? line.dataset.dst : line.dataset.src;
+        const otherNode = nodeMap.get(otherId);
+        if (otherNode) {
+          otherNode.classList.toggle('course-graph__node--highlighted', active);
+        }
+      }
+    });
+  };
+
+  const unlockNode = (node) => {
+    if (!node || node.dataset.locked !== 'true') return;
+    node.dataset.locked = 'false';
+    node.classList.remove('course-graph__node--locked');
+    node.classList.add('course-graph__node--active', 'course-graph__node--just-unlocked');
+    node.disabled = false;
+    node.addEventListener(
+      'animationend',
+      () => {
+        node.classList.remove('course-graph__node--just-unlocked');
+      },
+      { once: true }
+    );
+    updateEdges();
+  };
+
+  nodeElements.forEach((node) => {
+    const nodeId = node.dataset.nodeId;
+    if (!nodeId) return;
+
+    node.addEventListener('mouseenter', () => highlightConnected(nodeId, true));
+    node.addEventListener('mouseleave', () => highlightConnected(nodeId, false));
+    node.addEventListener('focus', () => highlightConnected(nodeId, true));
+    node.addEventListener('blur', () => highlightConnected(nodeId, false));
+    node.addEventListener('click', () => {
+      if (node.dataset.locked === 'true') return;
+      const url = node.dataset.url;
+      if (url) {
+        window.location.assign(url);
+      }
+    });
+  });
+
+  graphEl.addEventListener('courseGraph:unlock', (event) => {
+    const detail = event.detail || {};
+    if (!detail.nodeId) return;
+    const node = nodeMap.get(String(detail.nodeId));
+    if (node) {
+      unlockNode(node);
+    }
+  });
+
+  const resizeObserver = window.ResizeObserver
+    ? new ResizeObserver(() => updateEdges())
+    : null;
+
+  if (resizeObserver) {
+    resizeObserver.observe(graphEl);
+  } else {
+    window.addEventListener('resize', updateEdges);
+  }
+
+  requestAnimationFrame(updateEdges);
+
+  graphEl.dataset.graphReady = 'true';
+}
+
+function initGraphs() {
+  const graphs = document.querySelectorAll('[data-course-graph]');
+  graphs.forEach((graph) => initGraph(graph));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initGraphs);
+} else {
+  initGraphs();
+}
+
+export { initGraphs };


### PR DESCRIPTION
## Summary
- replace the dashboard course progress bar with an interactive module graph that renders nodes, edges, and circular progress rings
- add gradient-driven styling for the new graph component along with locked/active states and module detail page styles
- provide a JavaScript controller for hover, unlock, and navigation behavior plus a dedicated module detail route

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d6570d447c832dbe960604676659c2