### PR TITLE
Add course module detail view and dashboard navigation

### DIFF
--- a/accounts/templates/accounts/dashboard/courses.html
+++ b/accounts/templates/accounts/dashboard/courses.html
@@ -41,6 +41,25 @@
             <p class="course-card__progress-label">
               {% blocktrans with progress=enrollment.progress|floatformat:'-1' %}Прогресс: {{ progress }}%{% endblocktrans %}
             </p>
+            {% with modules=course.modules.all %}
+              {% if modules %}
+                <div class="course-card__modules" role="group" aria-label="{% trans 'Модули курса' %}">
+                  {% for module in modules %}
+                    {% url 'courses:module-detail' course.slug module.slug as module_url %}
+                    <a
+                      class="course-graph__node{% if module.is_locked %} course-graph__node--locked{% endif %}"
+                      href="{% if module.is_locked %}#{% else %}{{ module_url }}{% endif %}"
+                      data-course-module-url="{{ module_url }}"
+                      data-course-module-slug="{{ module.slug }}"
+                      data-course-module-title="{{ module.title }}"
+                      {% if module.is_locked %}aria-disabled="true" tabindex="-1"{% endif %}
+                    >
+                      <span class="course-graph__node-title">{{ module.title }}</span>
+                    </a>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            {% endwith %}
           </article>
         {% endwith %}
       {% endfor %}

--- a/courses/templates/courses/module_detail.html
+++ b/courses/templates/courses/module_detail.html
@@ -1,0 +1,190 @@
+{% extends 'accounts/dashboard/base.html' %}
+{% load i18n %}
+
+{% block dashboard_title %}{{ module.title }}{% endblock %}
+
+{% block dashboard_content %}
+  <nav class="module-breadcrumbs" aria-label="{% trans 'Навигация по курсу' %}">
+    <a class="module-breadcrumbs__link" href="{% url 'accounts:dashboard-courses' %}">{% trans 'К курсам' %}</a>
+    <span aria-hidden="true" class="module-breadcrumbs__separator">/</span>
+    <span class="module-breadcrumbs__current">{{ course.title }}</span>
+  </nav>
+
+  {% if submission_feedback %}
+    <div class="module-feedback module-feedback--{{ submission_feedback.level }}">
+      {{ submission_feedback.message }}
+    </div>
+  {% endif %}
+
+  <header class="module-header">
+    <h2 class="module-header__title">{{ module.title }}</h2>
+    {% if module.subtitle %}
+      <p class="module-header__subtitle">{{ module.subtitle }}</p>
+    {% endif %}
+    {% if module.description %}
+      <p class="module-header__description">{{ module.description }}</p>
+    {% endif %}
+    <div class="module-header__progress" role="progressbar" aria-valuenow="{{ module_mastery_percent|floatformat:'-2' }}" aria-valuemin="0" aria-valuemax="100">
+      <span class="module-header__progress-bar" style="width: {{ module_mastery_percent|floatformat:'-2' }}%;"></span>
+      <span class="module-header__progress-label">
+        {% blocktrans with value=module_mastery_percent|floatformat:'-1' %}Мастерство: {{ value }}%{% endblocktrans %}
+      </span>
+    </div>
+  </header>
+
+  <div class="module-layout">
+    <aside class="module-sidebar" aria-label="{% trans 'Список модулей' %}">
+      <h3 class="module-sidebar__title">{% trans 'Модули курса' %}</h3>
+      <ul class="module-sidebar__list">
+        {% for sibling in sibling_modules %}
+          <li class="module-sidebar__item{% if sibling.pk == module.pk %} module-sidebar__item--active{% endif %}">
+            {% if sibling.is_locked and sibling.pk != module.pk %}
+              <span class="module-sidebar__link module-sidebar__link--locked">{{ sibling.title }}</span>
+            {% else %}
+              <a class="module-sidebar__link{% if sibling.is_locked %} module-sidebar__link--locked{% endif %}" href="{% url 'courses:module-detail' course.slug sibling.slug %}" {% if sibling.pk == module.pk %}aria-current="page"{% endif %}>{{ sibling.title }}</a>
+            {% endif %}
+          </li>
+        {% empty %}
+          <li class="module-sidebar__item module-sidebar__item--empty">{% trans 'Нет других модулей.' %}</li>
+        {% endfor %}
+      </ul>
+    </aside>
+
+    <section class="module-items" aria-label="{% trans 'Элементы модуля' %}">
+      <h3 class="module-items__title">{% trans 'Элементы модуля' %}</h3>
+      <ol class="module-items__list">
+        {% for entry in item_states %}
+          {% with item=entry.object state=entry.state %}
+            <li class="module-items__item module-items__item--{{ state }}">
+              <span class="module-items__badge">
+                {% if state == 'completed' %}
+                  {% trans 'Пройдено' %}
+                {% elif state == 'current' %}
+                  {% trans 'Текущий' %}
+                {% elif state == 'locked' %}
+                  {% trans 'Закрыто' %}
+                {% else %}
+                  {% trans 'Доступно' %}
+                {% endif %}
+              </span>
+              <span class="module-items__name">
+                {% if item.kind == item.ItemKind.THEORY %}
+                  {{ item.theory_card.title }}
+                {% else %}
+                  {{ item.task.title }}
+                {% endif %}
+              </span>
+              <span class="module-items__thresholds">
+                {% blocktrans with min=item.min_mastery_percent max=item.max_mastery_percent %}{{ min }}–{{ max }}%{% endblocktrans %}
+              </span>
+            </li>
+          {% endwith %}
+        {% empty %}
+          <li class="module-items__item module-items__item--empty">{% trans 'В модуле пока нет элементов.' %}</li>
+        {% endfor %}
+      </ol>
+      <div class="module-items__nav">
+        <div class="module-items__nav-item">
+          <span class="module-items__nav-label">{% trans 'Предыдущий элемент' %}</span>
+          {% if previous_item %}
+            <span class="module-items__nav-value">
+              {% if previous_item.kind == previous_item.ItemKind.THEORY %}
+                {{ previous_item.theory_card.title }}
+              {% else %}
+                {{ previous_item.task.title }}
+              {% endif %}
+            </span>
+            {% if previous_item_state %}
+              <span class="module-items__nav-state module-items__nav-state--{{ previous_item_state }}">
+                {% if previous_item_state == 'completed' %}
+                  {% trans 'Пройдено' %}
+                {% elif previous_item_state == 'locked' %}
+                  {% trans 'Закрыто' %}
+                {% elif previous_item_state == 'current' %}
+                  {% trans 'Текущий' %}
+                {% else %}
+                  {% trans 'Доступно' %}
+                {% endif %}
+              </span>
+            {% endif %}
+          {% else %}
+            <span class="module-items__nav-empty">{% trans 'Это первый элемент' %}</span>
+          {% endif %}
+        </div>
+        <div class="module-items__nav-item">
+          <span class="module-items__nav-label">{% trans 'Следующий элемент' %}</span>
+          {% if next_item %}
+            <span class="module-items__nav-value">
+              {% if next_item.kind == next_item.ItemKind.THEORY %}
+                {{ next_item.theory_card.title }}
+              {% else %}
+                {{ next_item.task.title }}
+              {% endif %}
+            </span>
+            {% if next_item_state %}
+              <span class="module-items__nav-state module-items__nav-state--{{ next_item_state }}">
+                {% if next_item_state == 'completed' %}
+                  {% trans 'Пройдено' %}
+                {% elif next_item_state == 'locked' %}
+                  {% trans 'Закрыто' %}
+                {% elif next_item_state == 'current' %}
+                  {% trans 'Текущий' %}
+                {% else %}
+                  {% trans 'Доступно' %}
+                {% endif %}
+              </span>
+            {% endif %}
+          {% else %}
+            <span class="module-items__nav-empty">{% trans 'Вы на последнем элементе' %}</span>
+          {% endif %}
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <section class="module-content" aria-label="{% trans 'Текущий материал' %}">
+    <h3 class="module-content__title">{% trans 'Текущий материал' %}</h3>
+    {% if current_item %}
+      <article class="module-content__card module-content__card--{{ current_item.kind }}">
+        {% if current_item.kind == current_item.ItemKind.THEORY %}
+          <header class="module-content__header">
+            <h4>{{ current_item.theory_card.title }}</h4>
+            {% if current_item.theory_card.subtitle %}
+              <p class="module-content__subtitle">{{ current_item.theory_card.subtitle }}</p>
+            {% endif %}
+          </header>
+          <div class="module-content__body">
+            {% if current_item.theory_card.content_format == current_item.theory_card.ContentFormat.HTML %}
+              {{ current_item.theory_card.content|safe }}
+            {% else %}
+              {{ current_item.theory_card.content|linebreaks }}
+            {% endif %}
+          </div>
+        {% else %}
+          <header class="module-content__header">
+            <h4>{{ current_item.task.title }}</h4>
+          </header>
+          {% if current_item.task.description %}
+            <div class="module-content__body">
+              {{ current_item.task.description|linebreaks }}
+            </div>
+          {% endif %}
+          <footer class="module-content__footer">
+            <form method="post" class="module-content__form">
+              {% csrf_token %}
+              <fieldset>
+                <legend>{% trans 'Результат попытки' %}</legend>
+                <div class="module-content__actions">
+                  <button type="submit" name="result" value="success" class="module-content__action module-content__action--primary">{% trans 'Я решил задачу' %}</button>
+                  <button type="submit" name="result" value="retry" class="module-content__action">{% trans 'Нужно повторить' %}</button>
+                </div>
+              </fieldset>
+            </form>
+          </footer>
+        {% endif %}
+      </article>
+    {% else %}
+      <p class="muted">{% trans 'В этом модуле пока нет материалов.' %}</p>
+    {% endif %}
+  </section>
+{% endblock %}

--- a/courses/tests.py
+++ b/courses/tests.py
@@ -1,3 +1,103 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from .models import (
+    Course,
+    CourseEnrollment,
+    CourseModule,
+    CourseModuleItem,
+    CourseTheoryCard,
+)
+
+
+class ModuleDetailViewTests(TestCase):
+    """Tests for the course module detail view."""
+
+    def setUp(self) -> None:
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="student",
+            email="student@example.com",
+            password="password123",
+        )
+        self.other_user = user_model.objects.create_user(
+            username="outsider",
+            email="outsider@example.com",
+            password="password123",
+        )
+
+        self.course = Course.objects.create(
+            slug="math",
+            title="Математика",
+        )
+        self.module = CourseModule.objects.create(
+            course=self.course,
+            slug="module-1",
+            title="Основы",
+            kind=CourseModule.Kind.SELF_PACED,
+            rank=1,
+        )
+
+        self.card_intro = CourseTheoryCard.objects.create(
+            course=self.course,
+            slug="intro",
+            title="Введение",
+            content="Первый шаг",
+        )
+        self.card_next = CourseTheoryCard.objects.create(
+            course=self.course,
+            slug="deep-dive",
+            title="Продвинутый материал",
+            content="Продолжаем обучение",
+        )
+
+        CourseModuleItem.objects.create(
+            module=self.module,
+            kind=CourseModuleItem.ItemKind.THEORY,
+            theory_card=self.card_intro,
+            position=1,
+            min_mastery_percent=0,
+            max_mastery_percent=30,
+        )
+        CourseModuleItem.objects.create(
+            module=self.module,
+            kind=CourseModuleItem.ItemKind.THEORY,
+            theory_card=self.card_next,
+            position=2,
+            min_mastery_percent=31,
+            max_mastery_percent=100,
+        )
+
+        self.enrollment = CourseEnrollment.objects.create(
+            course=self.course,
+            student=self.user,
+            status=CourseEnrollment.Status.ENROLLED,
+            progress=0,
+        )
+
+    def test_requires_enrollment(self) -> None:
+        """Users without an enrollment cannot access the module."""
+
+        self.client.login(username="outsider", password="password123")
+        response = self.client.get(
+            reverse("courses:module-detail", args=[self.course.slug, self.module.slug])
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_selects_item_based_on_mastery(self) -> None:
+        """The item selected in the context matches the mastery thresholds."""
+
+        self.enrollment.progress = 45
+        self.enrollment.save(update_fields=["progress"])
+
+        self.client.login(username="student", password="password123")
+        response = self.client.get(
+            reverse("courses:module-detail", args=[self.course.slug, self.module.slug])
+        )
+        self.assertEqual(response.status_code, 200)
+        current_item = response.context["current_item"]
+        self.assertIsNotNone(current_item)
+        self.assertEqual(current_item.theory_card, self.card_next)
+        self.assertContains(response, self.card_next.title)
+        self.assertContains(response, "Мастерство")

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from .views import module_detail
+
+app_name = "courses"
+
+urlpatterns = [
+    path(
+        "courses/<slug:course_slug>/modules/<slug:module_slug>/",
+        module_detail,
+        name="module-detail",
+    ),
+]

--- a/courses/views.py
+++ b/courses/views.py
@@ -1,3 +1,167 @@
-from django.shortcuts import render
+from __future__ import annotations
 
-# Create your views here.
+from typing import Iterable
+
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
+from django.db.models import Prefetch
+from django.shortcuts import get_object_or_404, render
+from django.utils.translation import gettext as _
+
+from apps.recsys.models import SkillMastery, TypeMastery
+
+from .models import Course, CourseEnrollment, CourseModule, CourseModuleItem
+
+
+def _determine_dashboard_role(request) -> str:
+    """Return the dashboard role stored in the session (defaults to ``student``)."""
+
+    role = request.session.get("dashboard_role")
+    if role in {"student", "teacher"}:
+        return role
+    request.session["dashboard_role"] = "student"
+    return "student"
+
+
+def _module_mastery_percent(enrollment: CourseEnrollment, module: CourseModule) -> float:
+    """Return the user's mastery for the given module as a percentage."""
+
+    user = enrollment.student
+    mastery_percent = 0.0
+
+    if module.kind == CourseModule.Kind.SKILL and module.skill_id:
+        mastery = SkillMastery.objects.filter(user=user, skill=module.skill).first()
+        if mastery is not None:
+            mastery_percent = float(mastery.mastery) * 100
+    elif module.kind == CourseModule.Kind.TASK_TYPE and module.task_type_id:
+        mastery = TypeMastery.objects.filter(user=user, task_type=module.task_type).first()
+        if mastery is not None:
+            mastery_percent = float(mastery.mastery) * 100
+    else:
+        mastery_percent = float(enrollment.progress or 0)
+
+    return max(0.0, min(100.0, mastery_percent))
+
+
+def _select_current_item(
+    items: Iterable[CourseModuleItem], mastery_percent: float
+) -> CourseModuleItem | None:
+    """Return the module item that should be presented to the learner."""
+
+    items_list = list(items)
+    for item in items_list:
+        if item.min_mastery_percent <= mastery_percent <= item.max_mastery_percent:
+            return item
+    if not items_list:
+        return None
+    if mastery_percent < items_list[0].min_mastery_percent:
+        return items_list[0]
+    return items_list[-1]
+
+
+@login_required
+def module_detail(request, course_slug: str, module_slug: str):
+    """Display the current learning item for a course module."""
+
+    course = get_object_or_404(
+        Course.objects.select_related("layout").prefetch_related("modules"),
+        slug=course_slug,
+        is_active=True,
+    )
+
+    enrollment = CourseEnrollment.objects.filter(
+        course=course, student=request.user
+    ).select_related("course", "student").first()
+    if enrollment is None:
+        raise PermissionDenied("Вы не записаны на этот курс.")
+
+    module_qs = CourseModule.objects.select_related("course", "skill", "task_type").prefetch_related(
+        Prefetch(
+            "items",
+            queryset=CourseModuleItem.objects.select_related("theory_card", "task").order_by(
+                "position", "pk"
+            ),
+        )
+    )
+    module = get_object_or_404(module_qs, course=course, slug=module_slug)
+
+    if module.is_locked:
+        raise PermissionDenied("Этот модуль ещё закрыт.")
+
+    submission_feedback: dict[str, str] | None = None
+    if request.method == "POST":
+        result = request.POST.get("result")
+        if result == "success":
+            submission_feedback = {
+                "level": "success",
+                "message": _("Результат сохранён. Если вы готовы, переходите к следующему элементу."),
+            }
+        elif result == "retry":
+            submission_feedback = {
+                "level": "info",
+                "message": _("Мы отметили, что нужно повторить этот материал."),
+            }
+        else:
+            submission_feedback = {
+                "level": "warning",
+                "message": _("Выберите доступное действие, чтобы продолжить."),
+            }
+
+    items = list(module.items.all())
+    mastery_percent = _module_mastery_percent(enrollment, module)
+    current_item = _select_current_item(items, mastery_percent)
+    current_item_state = None
+    if current_item is not None:
+        if mastery_percent < current_item.min_mastery_percent:
+            current_item_state = "locked"
+        elif mastery_percent > current_item.max_mastery_percent:
+            current_item_state = "completed"
+        else:
+            current_item_state = "current"
+
+    item_states: list[dict[str, object]] = []
+    current_index = -1
+    if current_item is not None:
+        try:
+            current_index = items.index(current_item)
+        except ValueError:
+            current_index = -1
+
+    previous_item = items[current_index - 1] if current_index > 0 else None
+    next_item = items[current_index + 1] if current_index >= 0 and current_index + 1 < len(items) else None
+    previous_state = None
+    next_state = None
+
+    for index, item in enumerate(items):
+        if mastery_percent < item.min_mastery_percent:
+            state = "locked"
+        elif mastery_percent > item.max_mastery_percent:
+            state = "completed"
+        else:
+            state = "available"
+        if index == current_index:
+            state = "current" if state == "available" else state
+        item_states.append({"object": item, "state": state})
+        if item is previous_item:
+            previous_state = state
+        if item is next_item:
+            next_state = state
+
+    context = {
+        "active_tab": "courses",
+        "role": _determine_dashboard_role(request),
+        "course": course,
+        "module": module,
+        "enrollment": enrollment,
+        "module_mastery_percent": mastery_percent,
+        "current_item": current_item,
+        "current_item_state": current_item_state,
+        "previous_item": previous_item,
+        "previous_item_state": previous_state,
+        "next_item": next_item,
+        "next_item_state": next_state,
+        "item_states": item_states,
+        "sibling_modules": list(course.modules.all()),
+        "submission_feedback": submission_feedback,
+    }
+    return render(request, "courses/module_detail.html", context)

--- a/fractalschool/urls.py
+++ b/fractalschool/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('accounts/', include('accounts.urls')),
     path('applications/', include(('applications.urls', 'applications'), namespace='applications')),
+    path('', include(('courses.urls', 'courses'), namespace='courses')),
 
     path('', include('apps.recsys.api.urls')),
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -295,6 +295,46 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
   color: var(--muted);
 }
 
+.course-card__modules {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-top: var(--space-sm);
+}
+
+.course-graph__node {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--card) 90%, #0b1017);
+  color: inherit;
+  text-decoration: none;
+  font-size: var(--font-sm);
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.course-graph__node:hover,
+.course-graph__node:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+
+.course-graph__node--locked {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.course-graph__node--locked:hover,
+.course-graph__node--locked:focus-visible {
+  border-color: var(--border);
+  color: inherit;
+}
+
 /* Custom checkbox inside pill */
 .pill-check .tick {
   width: 18px;
@@ -349,6 +389,297 @@ header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(10px); bac
 .auth-form label { display:block; margin-bottom:var(--space-xs); }
 .auth-form input { width:100%; padding:var(--space-sm); border:1px solid var(--border); border-radius:8px; background:var(--bg); color:var(--text); }
 .auth-form .helptext { display:block; margin-top:var(--space-xs); color:var(--muted); font-size:var(--font-sm); }
+
+.module-breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--font-sm);
+  margin-bottom: var(--space-sm);
+  color: var(--muted);
+}
+
+.module-breadcrumbs__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.module-breadcrumbs__link:hover,
+.module-breadcrumbs__link:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+.module-feedback {
+  margin-bottom: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: 10px;
+  border-left: 4px solid var(--border);
+  background: color-mix(in srgb, var(--card) 85%, #0b1017);
+}
+
+.module-feedback--success { border-left-color: var(--accent); }
+.module-feedback--info { border-left-color: color-mix(in srgb, var(--accent) 55%, var(--border)); }
+.module-feedback--warning { border-left-color: #f0a500; }
+
+.module-header {
+  display: grid;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-lg);
+}
+
+.module-header__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 2vw, 1.8rem);
+}
+
+.module-header__subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.module-header__description {
+  margin: 0;
+  color: var(--muted);
+}
+
+.module-header__progress {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 18%, #0b1017);
+  overflow: hidden;
+  min-height: 32px;
+}
+
+.module-header__progress-bar {
+  position: absolute;
+  inset: 0;
+  background: var(--accent);
+  border-radius: inherit;
+  opacity: 0.85;
+}
+
+.module-header__progress-label {
+  position: relative;
+  z-index: 1;
+  font-size: var(--font-sm);
+  font-weight: 600;
+}
+
+.module-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) 1fr;
+  gap: var(--space-lg);
+  align-items: start;
+  margin-bottom: var(--space-xl);
+}
+
+.module-sidebar__title {
+  margin-top: 0;
+  font-size: var(--font-lg);
+}
+
+.module-sidebar__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.module-sidebar__item--active .module-sidebar__link {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.module-sidebar__link {
+  display: block;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--card) 92%, #0b1017);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.module-sidebar__link:hover,
+.module-sidebar__link:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+
+.module-sidebar__link--locked {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.module-items__title {
+  margin-top: 0;
+  font-size: var(--font-lg);
+}
+
+.module-items__list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: var(--space-xs);
+}
+
+.module-items__item {
+  display: grid;
+  grid-template-columns: minmax(120px, max-content) 1fr max-content;
+  gap: var(--space-sm);
+  align-items: center;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--card) 95%, #0b1017);
+}
+
+.module-items__item--completed {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+}
+
+.module-items__item--locked {
+  opacity: 0.6;
+}
+
+.module-items__badge {
+  font-size: var(--font-xs, 0.75rem);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.module-items__name {
+  font-weight: 600;
+}
+
+.module-items__thresholds {
+  font-size: var(--font-sm);
+  color: var(--muted);
+}
+
+.module-items__nav {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+.module-items__nav-item {
+  display: grid;
+  gap: 4px;
+  padding: var(--space-sm);
+  border-radius: 12px;
+  border: 1px dashed var(--border);
+}
+
+.module-items__nav-label {
+  font-size: var(--font-sm);
+  color: var(--muted);
+}
+
+.module-items__nav-value {
+  font-weight: 600;
+}
+
+.module-items__nav-state {
+  font-size: var(--font-sm);
+  color: var(--muted);
+}
+
+.module-items__nav-empty {
+  color: var(--muted);
+}
+
+.module-content__title {
+  margin-top: 0;
+  font-size: var(--font-lg);
+}
+
+.module-content__card {
+  background: color-mix(in srgb, var(--card) 92%, #0b1017);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: var(--space-md);
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.module-content__header h4 {
+  margin: 0;
+  font-size: clamp(1.1rem, 2vw, 1.4rem);
+}
+
+.module-content__subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.module-content__body p {
+  margin-top: 0;
+  margin-bottom: var(--space-sm);
+}
+
+.module-content__form fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.module-content__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+}
+
+.module-content__action {
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
+}
+
+.module-content__action:hover,
+.module-content__action:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: none;
+}
+
+.module-content__action--primary {
+  background: var(--accent);
+  color: #030712;
+  border-color: var(--accent);
+}
+
+.module-content__action--primary:hover,
+.module-content__action--primary:focus-visible {
+  filter: brightness(1.05);
+}
+
+@media (max-width: 960px) {
+  .module-layout {
+    grid-template-columns: 1fr;
+    gap: var(--space-md);
+  }
+
+  .module-items__item {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+}
 
 /* Signup form */
 .signup-form { display:grid; gap:var(--space-md); }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -188,6 +188,16 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
+document.addEventListener('click', (event) => {
+  const node = event.target.closest('[data-course-module-url]');
+  if (!node) return;
+  const url = node.getAttribute('data-course-module-url');
+  if (!url || node.classList.contains('course-graph__node--locked')) return;
+  if (node.tagName === 'A' && node.getAttribute('href')) return;
+  event.preventDefault();
+  window.location.href = url;
+});
+
 if (typeof module !== 'undefined') {
   module.exports = { updatePrice };
 }


### PR DESCRIPTION
## Summary
- add a course module detail view that selects the next visible item from mastery thresholds and renders a new template
- surface module navigation in the dashboard courses tab with supporting styles and JS to route graph node clicks
- cover the new flow with dedicated tests and expose the module detail URL in the project router

## Testing
- python manage.py test courses

------
https://chatgpt.com/codex/tasks/task_e_68d661702688832d9964fa0c915dec30