### PR TITLE
Implement mastery-aware module detail page

### DIFF
--- a/courses/templates/courses/module_detail.html
+++ b/courses/templates/courses/module_detail.html
@@ -18,6 +18,16 @@
       {% if module.subtitle %}
         <p class="module-detail__subtitle">{{ module.subtitle }}</p>
       {% endif %}
+      <dl class="module-detail__stats">
+        <div>
+          <dt>{% trans 'Освоение модуля' %}</dt>
+          <dd>{{ module_mastery_percent|floatformat:'-1' }}%</dd>
+        </div>
+        <div>
+          <dt>{% trans 'Количество элементов' %}</dt>
+          <dd>{{ items|length }}</dd>
+        </div>
+      </dl>
     </header>
 
     {% if module.description %}
@@ -28,7 +38,7 @@
       <section class="module-detail__relations" aria-label="{% trans 'Связи модуля' %}">
         {% if incoming_edges %}
           <div>
-            <h3>{% trans 'Требуется перед' %}</h3>
+            <h3>{% trans 'Требует перед собой' %}</h3>
             <ul>
               {% for edge in incoming_edges %}
                 <li>{{ edge.src.title }}</li>
@@ -38,7 +48,7 @@
         {% endif %}
         {% if outgoing_edges %}
           <div>
-            <h3>{% trans 'Открывает путь к' %}</h3>
+            <h3>{% trans 'Открывает после прохождения' %}</h3>
             <ul>
               {% for edge in outgoing_edges %}
                 <li>{{ edge.dst.title }}</li>
@@ -49,30 +59,156 @@
       </section>
     {% endif %}
 
-    {% if items %}
-      <section class="module-detail__items" aria-label="{% trans 'Содержимое модуля' %}">
-        <h3>{% trans 'Элементы модуля' %}</h3>
-        <ol>
-          {% for item in items %}
-            <li>
-              <strong>
-                {% if item.kind == item.ItemKind.THEORY %}
-                  {% trans 'Теория' %}
-                {% elif item.kind == item.ItemKind.TASK %}
-                  {% trans 'Задание' %}
+    <div class="module-detail__layout">
+      <aside class="module-detail__sidebar" aria-label="{% trans 'Элементы модуля' %}">
+        <h3>{% trans 'Содержимое модуля' %}</h3>
+        {% if items_with_state %}
+          <ol class="module-detail__items-list">
+            {% for entry in items_with_state %}
+              {% with item=entry.item %}
+                <li
+                  class="module-detail__item{% if entry.is_current %} module-detail__item--current{% endif %}{% if entry.is_visible %} module-detail__item--visible{% else %} module-detail__item--hidden{% endif %}"
+                  {% if entry.is_current %}aria-current="step"{% endif %}
+                >
+                  <span class="module-detail__item-index">{{ entry.position }}</span>
+                  <div class="module-detail__item-body">
+                    <span class="module-detail__item-kind">
+                      {% if item.kind == item.ItemKind.THEORY %}
+                        {% trans 'Теория' %}
+                      {% elif item.kind == item.ItemKind.TASK %}
+                        {% trans 'Задание' %}
+                      {% else %}
+                        {{ item.get_kind_display }}
+                      {% endif %}
+                    </span>
+                    <span class="module-detail__item-title">
+                      {% if item.theory_card %}
+                        {{ item.theory_card.title }}
+                      {% elif item.task %}
+                        {{ item.task.title|default:item.task.pk }}
+                      {% else %}
+                        #{{ item.pk }}
+                      {% endif %}
+                    </span>
+                    <span class="module-detail__item-range">
+                      {% blocktrans with min=item.min_mastery_percent max=item.max_mastery_percent %}от {{ min }}% до {{ max }}%{% endblocktrans %}
+                    </span>
+                    {% if entry.is_visible and not entry.is_current %}
+                      <a class="module-detail__item-link" href="?item={{ item.id }}">{% trans 'Перейти' %}</a>
+                    {% elif not entry.is_visible %}
+                      <span class="module-detail__item-locked">{% trans 'Недоступно при текущем прогрессе' %}</span>
+                    {% endif %}
+                  </div>
+                </li>
+              {% endwith %}
+            {% endfor %}
+          </ol>
+        {% else %}
+          <p class="muted">{% trans 'В модуле пока нет элементов.' %}</p>
+        {% endif %}
+      </aside>
+
+      <section class="module-detail__content" aria-live="polite">
+        {% if current_item %}
+          {% if not current_item_accessible %}
+            <div class="module-detail__alert module-detail__alert--warning">
+              {% blocktrans %}Текущий элемент недоступен при уровне освоения {{ module_mastery_percent|floatformat:'-1' }}%.{% endblocktrans %}
+            </div>
+          {% endif %}
+
+          <article class="module-detail__card">
+            <header class="module-detail__card-header">
+              <h3 class="module-detail__card-title">
+                {% if current_item.kind == current_item.ItemKind.THEORY and current_item.theory_card %}
+                  {{ current_item.theory_card.title }}
+                {% elif current_item.kind == current_item.ItemKind.TASK and current_item.task %}
+                  {{ current_item.task.title|default:current_item.task.pk }}
                 {% else %}
-                  {{ item.get_kind_display }}
+                  {% trans 'Элемент модуля' %}
                 {% endif %}
-              </strong>
-              {% if item.theory_card %}
-                — {{ item.theory_card.title }}
-              {% elif item.task %}
-                — {{ item.task.name|default:item.task.pk }}
+              </h3>
+              <p class="module-detail__card-meta">
+                {% if current_item.kind == current_item.ItemKind.THEORY %}
+                  {% trans 'Карточка теории' %}
+                {% elif current_item.kind == current_item.ItemKind.TASK %}
+                  {% trans 'Практическое задание' %}
+                {% endif %}
+              </p>
+            </header>
+
+            <div class="module-detail__card-body">
+              {% if current_item.kind == current_item.ItemKind.THEORY and current_item.theory_card %}
+                {% if current_item.theory_card.content_format == current_item.theory_card.ContentFormat.HTML %}
+                  <div class="module-detail__theory" data-format="html">
+                    {{ current_item.theory_card.content|safe }}
+                  </div>
+                {% else %}
+                  <div class="module-detail__theory" data-format="text">
+                    {{ current_item.theory_card.content|linebreaks }}
+                  </div>
+                {% endif %}
+              {% elif current_item.kind == current_item.ItemKind.TASK and current_item.task %}
+                <div class="module-detail__task">
+                  {% if current_item.task.description %}
+                    {% if current_item.task.rendering_strategy == current_item.task.RenderingStrategy.HTML %}
+                      <div class="module-detail__task-description" data-format="html">
+                        {{ current_item.task.description|safe }}
+                      </div>
+                    {% else %}
+                      <div class="module-detail__task-description" data-format="text">
+                        {{ current_item.task.description|linebreaks }}
+                      </div>
+                    {% endif %}
+                  {% else %}
+                    <p class="muted">{% trans 'Описание задания пока отсутствует.' %}</p>
+                  {% endif %}
+                  <dl class="module-detail__task-meta">
+                    {% if current_item.task.type %}
+                      <div>
+                        <dt>{% trans 'Тип задания' %}</dt>
+                        <dd>{{ current_item.task.type.name }}</dd>
+                      </div>
+                    {% endif %}
+                    {% if current_item.task.subject %}
+                      <div>
+                        <dt>{% trans 'Предмет' %}</dt>
+                        <dd>{{ current_item.task.subject.name }}</dd>
+                      </div>
+                    {% endif %}
+                  </dl>
+                </div>
+              {% else %}
+                <p class="muted">{% trans 'Для этого элемента пока нет содержимого.' %}</p>
               {% endif %}
-            </li>
-          {% endfor %}
-        </ol>
+            </div>
+
+            <footer class="module-detail__card-footer">
+              <form method="post" class="module-detail__action-form">
+                {% csrf_token %}
+                <input type="hidden" name="item_id" value="{{ current_item.id }}">
+                <div class="module-detail__action-buttons">
+                  <button type="submit" name="action" value="success" class="btn btn--success">
+                    {% trans 'Завершено успешно' %}
+                  </button>
+                  <button type="submit" name="action" value="failure" class="btn btn--secondary">
+                    {% trans 'Нужна повторная попытка' %}
+                  </button>
+                </div>
+              </form>
+              <nav class="module-detail__card-navigation" aria-label="{% trans 'Навигация по элементам модуля' %}">
+                {% if previous_item %}
+                  <a class="module-detail__nav-link" href="?item={{ previous_item.id }}">{% trans '← Предыдущий доступный элемент' %}</a>
+                {% endif %}
+                {% if next_item %}
+                  <a class="module-detail__nav-link" href="?item={{ next_item.id }}">{% trans 'Следующий доступный элемент →' %}</a>
+                {% endif %}
+              </nav>
+            </footer>
+          </article>
+        {% else %}
+          <p class="muted">{% trans 'Доступные элементы не найдены. Попробуйте позже.' %}</p>
+        {% endif %}
       </section>
-    {% endif %}
+    </div>
   </div>
 {% endblock %}

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -5,5 +5,9 @@ from . import views
 app_name = "courses"
 
 urlpatterns = [
-    path("<slug:course_slug>/<slug:module_slug>/", views.module_detail, name="module-detail"),
+    path(
+        "<slug:course_slug>/modules/<slug:module_slug>/",
+        views.module_detail,
+        name="module-detail",
+    ),
 ]

--- a/courses/views.py
+++ b/courses/views.py
@@ -1,8 +1,16 @@
+from __future__ import annotations
+
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import Prefetch
-from django.shortcuts import get_object_or_404, render
+from django.http import Http404
+from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.http import urlencode
+from django.utils.translation import gettext as _
 
-from .models import Course, CourseGraphEdge, CourseModule, CourseModuleItem
+from apps.recsys.models import SkillMastery, TypeMastery
+
+from .models import Course, CourseGraphEdge, CourseEnrollment, CourseModule, CourseModuleItem
 
 
 @login_required
@@ -33,14 +41,152 @@ def module_detail(request, course_slug: str, module_slug: str):
         slug=module_slug,
     )
 
+    if module.is_locked:
+        raise Http404()
+
+    enrollment = request.user.course_enrollments.filter(course=course).first()
+    if enrollment is None:
+        raise Http404()
+
+    module_mastery_percent = _get_module_mastery_percent(request.user, module, enrollment)
+
+    items = list(module.items.all())
     incoming = [edge for edge in course.graph_edges.all() if edge.dst_id == module.id]
     outgoing = [edge for edge in course.graph_edges.all() if edge.src_id == module.id]
+
+    accessible_items = [
+        item
+        for item in items
+        if item.min_mastery_percent <= module_mastery_percent <= item.max_mastery_percent
+    ]
+
+    requested_item_id = request.GET.get("item") or request.POST.get("item_id")
+
+    def _get_item_by_id(item_id: str | None) -> CourseModuleItem | None:
+        if not item_id:
+            return None
+        for item in items:
+            if str(item.id) == str(item_id):
+                return item
+        return None
+
+    current_item = None
+    if requested_item_id:
+        candidate = _get_item_by_id(requested_item_id)
+        if candidate and candidate in accessible_items:
+            current_item = candidate
+
+    if current_item is None:
+        if accessible_items:
+            current_item = accessible_items[0]
+        elif items:
+            current_item = items[0]
+
+    def _find_neighbor(
+        source: CourseModuleItem | None, step: int
+    ) -> CourseModuleItem | None:
+        if source is None or source not in items:
+            return None
+        index = items.index(source)
+        while 0 <= index + step < len(items):
+            index += step
+            candidate = items[index]
+            if candidate in accessible_items:
+                return candidate
+        return None
+
+    previous_item = _find_neighbor(current_item, -1)
+    next_item = _find_neighbor(current_item, 1)
+
+    if request.method == "POST" and current_item:
+        action = request.POST.get("action") or ""
+        target = current_item
+
+        if action == "success":
+            if next_item:
+                messages.success(
+                    request,
+                    _("Элемент успешно завершён. Переходим к следующему."),
+                )
+                target = next_item
+            else:
+                messages.success(
+                    request,
+                    _("Элемент успешно завершён. Это последний доступный элемент."),
+                )
+        elif action == "failure":
+            if previous_item:
+                messages.warning(
+                    request,
+                    _("Попробуйте ещё раз предыдущий элемент."),
+                )
+                target = previous_item
+            else:
+                messages.warning(
+                    request,
+                    _("Предыдущие элементы недоступны. Продолжайте с текущего."),
+                )
+        elif action == "previous" and previous_item:
+            target = previous_item
+        elif action == "next" and next_item:
+            target = next_item
+
+        query = {"item": target.id} if target else {}
+        redirect_url = module.get_absolute_url()
+        if query:
+            redirect_url = f"{redirect_url}?{urlencode(query)}"
+        return redirect(redirect_url)
+
+    items_with_state = []
+    for index, item in enumerate(items, start=1):
+        items_with_state.append(
+            {
+                "item": item,
+                "position": index,
+                "is_visible": item in accessible_items,
+                "is_current": item == current_item,
+            }
+        )
 
     context = {
         "course": course,
         "module": module,
-        "items": list(module.items.all()),
         "incoming_edges": incoming,
         "outgoing_edges": outgoing,
+        "items": items,
+        "items_with_state": items_with_state,
+        "current_item": current_item,
+        "current_item_accessible": current_item in accessible_items if current_item else False,
+        "previous_item": previous_item,
+        "next_item": next_item,
+        "module_mastery_percent": module_mastery_percent,
     }
     return render(request, "courses/module_detail.html", context)
+
+
+def _get_module_mastery_percent(user, module: CourseModule, enrollment: CourseEnrollment) -> float:
+    mastery_value: float | None = None
+
+    if module.kind == CourseModule.Kind.SKILL and module.skill_id:
+        mastery_value = (
+            SkillMastery.objects.filter(user=user, skill=module.skill)
+            .values_list("mastery", flat=True)
+            .first()
+        )
+    elif module.kind == CourseModule.Kind.TASK_TYPE and module.task_type_id:
+        mastery_value = (
+            TypeMastery.objects.filter(user=user, task_type=module.task_type)
+            .values_list("mastery", flat=True)
+            .first()
+        )
+    else:
+        mastery_value = float(enrollment.progress or 0)
+
+    if mastery_value is None:
+        return 0.0
+
+    mastery_percent = float(mastery_value)
+    if mastery_percent <= 1.0:
+        mastery_percent *= 100.0
+
+    return max(0.0, min(100.0, mastery_percent))


### PR DESCRIPTION
## Summary
- add a mastery-aware module detail view that enforces access rules and surfaces navigation helpers
- redesign the module detail template to show the active item, mastery information, and result controls
- update the module detail URL to include the `modules/` segment for direct navigation

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d668dfe220832dac912b5df5639519