### PR TITLE
Ensure tasks list uses single-column layout

### DIFF
--- a/static/css/cyber.css
+++ b/static/css/cyber.css
@@ -76,6 +76,28 @@ section{margin:28px 0;}
 @media (min-width:700px){ .grid{ grid-template-columns: repeat(2, minmax(0,1fr)); }}
 @media (min-width:1000px){ .grid{ grid-template-columns: repeat(3, minmax(0,1fr)); }}
 
+.tasks-grid{
+  display:grid;
+  gap:12px;
+  grid-template-columns:minmax(0,1fr);
+}
+@media (min-width:700px){
+  .tasks-grid{
+    grid-template-columns:minmax(0,1fr);
+  }
+}
+@media (min-width:1000px){
+  .tasks-grid{
+    grid-template-columns:minmax(0,1fr);
+  }
+}
+
+.tasks-grid .card{
+  width:100%;
+  height:100%;
+  box-sizing:border-box;
+}
+
 .item{display:flex; flex-direction:column; gap:8px;}
 .label{display:flex; justify-content:space-between; gap:10px; font-weight:600;}
 .pct{color:var(--muted);}

--- a/templates/recsys/tasks_list.html
+++ b/templates/recsys/tasks_list.html
@@ -48,7 +48,7 @@
       </div>
     </form>
 
-    <div class="grid">
+    <div class="grid tasks-grid">
       {% for task in tasks %}
         <article class="card">
           <div class="section-title">{{ task.title }}</div>


### PR DESCRIPTION
## Summary
- update the tasks list template to apply a dedicated tasks-grid class
- add styling for tasks-grid to enforce a single-column layout and ensure cards stretch across the container

## Testing
- No tests were run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68dc0b5875f8832dbb54d0276de54914