### PR TITLE
Display full task descriptions

### DIFF
--- a/templates/recsys/tasks_list.html
+++ b/templates/recsys/tasks_list.html
@@ -62,7 +62,7 @@
             <span class="chip">{% trans 'сложность' %}: {{ task.difficulty_level }}</span>
           </div>
           {% if task.description %}
-            <p class="mt-8">{{ task.description|truncatechars:180 }}</p>
+            <p class="mt-8 task-description">{{ task.description|linebreaksbr }}</p>
           {% endif %}
         </article>
       {% empty %}


### PR DESCRIPTION
## Summary
- render full task descriptions on the recommendations task list without truncating
- convert newline characters to <br> tags so multi-line descriptions keep their formatting

## Testing
- DEBUG=True python manage.py runserver 0.0.0.0:8000 (manually checked /tasks/)


------
https://chatgpt.com/codex/tasks/task_e_68dc3ec8a838832dbd6d84d39ffb9ffb