### PR TITLE
Add Markdown dependency for custom template filter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ djangorestframework
 Pillow==10.2.0
 requests
 beautifulsoup4
+Markdown


### PR DESCRIPTION
## Summary
- add the Markdown package to requirements so the markdown_extras template tag can import successfully

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68dc511f56e4832db3cf446b7bcdec52