### PR TITLE
Narrow progress bar selectors in cyber theme

### DIFF
--- a/accounts/templates/accounts/dashboard/subjects.html
+++ b/accounts/templates/accounts/dashboard/subjects.html
@@ -23,11 +23,11 @@
                   {% with m=item.skill_masteries|get_item:gi.skill.id %}
                   {% with pct=m|default:0|mul:100 %}
                   <div class="item">
-                    <div class="label">
+                    <div class="progress-label">
                       <span>{{ gi.skill.name }}</span>
                       <span class="pct">{{ pct|floatformat:0 }}%</span>
                     </div>
-                    <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ pct|floatformat:0 }}" aria-label="{{ gi.skill.name }}">
+                    <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ pct|floatformat:0 }}" aria-label="{{ gi.skill.name }}">
                       <div class="fill" style="width: {{ pct }}%"></div>
                     </div>
                   </div>
@@ -57,11 +57,11 @@
                 {% with m=item.type_masteries|get_item:t.id %}
                 {% with pct=m|default:0|mul:100 %}
                 <div class="item">
-                  <div class="label">
+                  <div class="progress-label">
                     <span>{{ t.name }}</span>
                     <span class="pct">{{ pct|floatformat:0 }}%</span>
                   </div>
-                  <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ pct|floatformat:0 }}" aria-label="{{ t.name }}">
+                  <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ pct|floatformat:0 }}" aria-label="{{ t.name }}">
                     <div class="fill" style="width: {{ pct }}%"></div>
                   </div>
                 </div>

--- a/static/css/cyber.css
+++ b/static/css/cyber.css
@@ -99,9 +99,9 @@ section{margin:28px 0;}
 }
 
 .item{display:flex; flex-direction:column; gap:8px;}
-.label{display:flex; justify-content:space-between; gap:10px; font-weight:600;}
+.progress-label{display:flex; justify-content:space-between; gap:10px; font-weight:600;}
 .pct{color:var(--muted);}
-.bar{position:relative; height:14px; border-radius:10px; overflow:hidden; background: #0a1411; border:1px solid var(--outline);}    
+.progress-bar{position:relative; height:14px; border-radius:10px; overflow:hidden; background: #0a1411; border:1px solid var(--outline);}
 .fill{position:absolute; inset:0 auto 0 0; width:0%; background:linear-gradient(90deg, rgba(0,255,156,.9), rgba(156,107,255,.85)); box-shadow: inset 0 0 12px rgba(0,0,0,.35), 0 0 18px rgba(0,255,156,.35);
   transition:width .35s ease;}
 

--- a/ваш_прогресс.txt
+++ b/ваш_прогресс.txt
@@ -55,9 +55,9 @@
     @media (min-width:1000px){ .grid{ grid-template-columns: repeat(3, minmax(0,1fr)); }}
 
     .item{display:flex; flex-direction:column; gap:8px;}
-    .label{display:flex; justify-content:space-between; gap:10px; font-weight:600;}
+    .progress-label{display:flex; justify-content:space-between; gap:10px; font-weight:600;}
     .pct{color:var(--muted);}
-    .bar{position:relative; height:14px; border-radius:10px; overflow:hidden; background: #0a1411; border:1px solid var(--outline);}    
+    .progress-bar{position:relative; height:14px; border-radius:10px; overflow:hidden; background: #0a1411; border:1px solid var(--outline);}
     .fill{position:absolute; inset:0 auto 0 0; width:0%; background:linear-gradient(90deg, rgba(0,255,156,.9), rgba(156,107,255,.85)); box-shadow: inset 0 0 12px rgba(0,0,0,.35), 0 0 18px rgba(0,255,156,.35);
       transition:width .35s ease;}
 
@@ -173,8 +173,8 @@
       const box = document.createElement('div');
       box.className = 'item';
       box.innerHTML = `
-        <div class="label"><span>${label}</span><span class="pct" id="pct-${id}">0%</span></div>
-        <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="${label}">
+        <div class="progress-label"><span>${label}</span><span class="pct" id="pct-${id}">0%</span></div>
+        <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="${label}">
           <div class="fill" id="fill-${id}" style="width:0%"></div>
         </div>`;
       return box;


### PR DESCRIPTION
## Summary
- rename the cyber theme progress bar selectors to `.progress-label`/`.progress-bar` to avoid clashing with generic labels
- update the dashboard subjects template and theme reference snippet to use the new class names

## Testing
- python manage.py collectstatic --noinput
- python manage.py migrate
- Manual verification: opened http://127.0.0.1:8000/tasks/


------
https://chatgpt.com/codex/tasks/task_e_68dcf05615ac832daf5141ab4c732336