### PR TITLE
Enhance TaskType string representation

### DIFF
--- a/apps/recsys/models.py
+++ b/apps/recsys/models.py
@@ -61,7 +61,14 @@ class TaskType(TimeStampedModel):
         ]
 
     def __str__(self) -> str:
-        return self.name
+        if self.exam_version:
+            prefix = self.exam_version.name
+            suffix = self.name
+            return f"{prefix} · {suffix}"
+
+        prefix = self.subject.name
+        suffix = f"{self.name} (без версии экзамена)"
+        return f"{prefix} · {suffix}"
 
     def clean(self):
         super().clean()


### PR DESCRIPTION
## Summary
- include exam version or subject information in TaskType string representation to distinguish similarly named types
- add clear indication when a task type lacks an associated exam version

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddc18475b8832d92981b413e85134d